### PR TITLE
refactor: Flatten the `StyleTree`

### DIFF
--- a/crates/browser-headless/src/commands/node.rs
+++ b/crates/browser-headless/src/commands/node.rs
@@ -11,9 +11,8 @@ pub fn cmd_node_id(engine: &HeadlessEngine, id: usize) -> Result<(), String> {
     };
 
     let document = page.document();
-    let node_id = NodeId(id);
     let node = document
-        .get_node(&node_id)
+        .get_node(&id.into())
         .ok_or_else(|| format!("Node {id} not found in DOM"))?;
 
     println!("Node {id}");
@@ -45,13 +44,12 @@ pub fn cmd_node_dom(engine: &HeadlessEngine, id: usize, max_depth: Option<usize>
     };
 
     let document = page.document();
-    let node_id = NodeId(id);
     document
-        .get_node(&node_id)
+        .get_node(&id.into())
         .ok_or_else(|| format!("Node {id} not found in DOM"))?;
 
     let mut output = String::new();
-    write_dom_subtree(document, node_id, 0, max_depth, &mut output).map_err(|e| e.to_string())?;
+    write_dom_subtree(document, id.into(), 0, max_depth, &mut output).map_err(|e| e.to_string())?;
 
     if output.trim().is_empty() {
         println!("Node {id} has no printable DOM output");
@@ -65,18 +63,16 @@ pub fn cmd_node_dom(engine: &HeadlessEngine, id: usize, max_depth: Option<usize>
 pub fn cmd_node_style(engine: &mut HeadlessEngine, config: &BrowserConfig, id: usize) -> Result<(), String> {
     engine.ensure_layout(config)?;
 
-    let node_id = NodeId(id);
-
     let Some(style_tree) = engine.style_tree.as_ref() else {
         return Err("Style tree not available".to_string());
     };
 
     let styled_node = style_tree
-        .find_node(node_id)
+        .get(id.into())
         .ok_or_else(|| format!("Node {id} not found in style tree"))?;
 
     println!("Computed style for node {id}:");
-    println!("{:#?}", styled_node.style);
+    println!("{:#?}", styled_node);
 
     Ok(())
 }
@@ -108,9 +104,8 @@ pub fn cmd_node_children(engine: &HeadlessEngine, id: usize, recursive: bool) ->
     };
 
     let document = page.document();
-    let node_id = NodeId(id);
     let node = document
-        .get_node(&node_id)
+        .get_node(&id.into())
         .ok_or_else(|| format!("Node {id} not found in DOM"))?;
 
     if node.children.is_empty() {
@@ -137,9 +132,7 @@ pub fn cmd_node_children(engine: &HeadlessEngine, id: usize, recursive: bool) ->
 }
 
 fn print_descendants(document: &DocumentRoot, node_id: NodeId, depth: usize) -> Result<(), String> {
-    let node = document
-        .get_node(&node_id)
-        .ok_or_else(|| format!("DOM references missing descendant node {}", node_id.0))?;
+    let node = &document[node_id];
 
     let indent = "  ".repeat(depth);
     println!("{}[{}] {}", indent, node_id.0, describe_node_type(node));

--- a/crates/browser-ui/src/renderer/program.rs
+++ b/crates/browser-ui/src/renderer/program.rs
@@ -88,9 +88,7 @@ impl<'html> HtmlRenderer<'html> {
         let nodes = self.layout_tree.resolve(f64::from(x), f64::from(y));
 
         for node in nodes {
-            let Some(dom_node) = self.dom_tree.get_node(&node.node_id) else {
-                continue;
-            };
+            let dom_node = &self.dom_tree[node.node_id];
 
             if let Some(n) = dom_node.data.as_element()
                 && n.tag == Tag::Html(HtmlTag::A)
@@ -103,7 +101,7 @@ impl<'html> HtmlRenderer<'html> {
                 );
             }
 
-            for ancestor in self.dom_tree.ancestors(&node.node_id) {
+            for ancestor in self.dom_tree.ancestors(dom_node) {
                 if let Some(n) = ancestor.data.as_element()
                     && n.tag == Tag::Html(HtmlTag::A)
                     && let Some(href) = n.attributes.as_ref().and_then(|attrs| attrs.get("href"))

--- a/crates/css-selectors/src/lib.rs
+++ b/crates/css-selectors/src/lib.rs
@@ -362,7 +362,7 @@ mod tests {
         let child_data = generate_node_data!(HtmlTag::Span, hash_set.clone(), HashMap::default());
         let child_id = tree.push_node(&child_data, Some(parent_id));
 
-        let child_node = tree.get_node(&child_id).unwrap();
+        let child_node = &tree[&child_id];
 
         assert!(matches_compound(&sequences, &tree, child_node, Some(&hash_set)));
     }
@@ -393,7 +393,7 @@ mod tests {
         let child_data = generate_node_data!(HtmlTag::P, hash_set.clone(), HashMap::default());
         let child_id = tree.push_node(&child_data, Some(parent_id));
 
-        let child_node = tree.get_node(&child_id).unwrap();
+        let child_node = &tree[&child_id];
 
         assert!(!matches_compound(&sequences, &tree, child_node, Some(&hash_set)));
     }
@@ -421,7 +421,7 @@ mod tests {
         let child_data = generate_node_data!(HtmlTag::Span, hash_set.clone(), HashMap::default());
         let child_id = tree.push_node(&child_data, Some(parent_id));
 
-        let child_node = tree.get_node(&child_id).unwrap();
+        let child_node = &tree[&child_id];
 
         assert!(matches_compound(&sequences, &tree, child_node, Some(&hash_set)));
     }
@@ -449,7 +449,7 @@ mod tests {
         let child_data = generate_node_data!(HtmlTag::P, hash_set.clone(), HashMap::default());
         let child_id = tree.push_node(&child_data, Some(parent_id));
 
-        let child_node = tree.get_node(&child_id).unwrap();
+        let child_node = &tree[&child_id];
 
         assert!(!matches_compound(&sequences, &tree, child_node, Some(&hash_set)));
     }
@@ -480,7 +480,7 @@ mod tests {
         let sibling2_data = generate_node_data!(HtmlTag::Span, hash_set.clone(), HashMap::default());
         let sibling2_id = tree.push_node(&sibling2_data, Some(parent_id));
 
-        let sibling2_node = tree.get_node(&sibling2_id).unwrap();
+        let sibling2_node = &tree[&sibling2_id];
 
         assert!(matches_compound(&sequences, &tree, sibling2_node, Some(&hash_set)));
     }
@@ -511,7 +511,7 @@ mod tests {
         let sibling2_data = generate_node_data!(HtmlTag::P, hash_set.clone(), HashMap::default());
         let sibling2_id = tree.push_node(&sibling2_data, Some(parent_id));
 
-        let sibling2_node = tree.get_node(&sibling2_id).unwrap();
+        let sibling2_node = &tree[&sibling2_id];
 
         assert!(!matches_compound(&sequences, &tree, sibling2_node, Some(&hash_set)));
     }
@@ -545,7 +545,7 @@ mod tests {
         let sibling3_data = generate_node_data!(HtmlTag::Span, hash_set.clone(), HashMap::default());
         let sibling3_id = tree.push_node(&sibling3_data, Some(parent_id));
 
-        let sibling3_node = tree.get_node(&sibling3_id).unwrap();
+        let sibling3_node = &tree[&sibling3_id];
 
         assert!(!matches_compound(&sequences, &tree, sibling3_node, Some(&hash_set)));
     }
@@ -576,7 +576,7 @@ mod tests {
         let sibling2_data = generate_node_data!(HtmlTag::Span, hash_set.clone(), HashMap::default());
         let sibling2_id = tree.push_node(&sibling2_data, Some(parent_id));
 
-        let sibling2_node = tree.get_node(&sibling2_id).unwrap();
+        let sibling2_node = &tree[&sibling2_id];
 
         assert!(matches_compound(&sequences, &tree, sibling2_node, Some(&hash_set)));
     }
@@ -607,7 +607,7 @@ mod tests {
         let sibling2_data = generate_node_data!(HtmlTag::P, hash_set.clone(), HashMap::default());
         let sibling2_id = tree.push_node(&sibling2_data, Some(parent_id));
 
-        let sibling2_node = tree.get_node(&sibling2_id).unwrap();
+        let sibling2_node = &tree[&sibling2_id];
 
         assert!(!matches_compound(&sequences, &tree, sibling2_node, Some(&hash_set)));
     }
@@ -641,7 +641,7 @@ mod tests {
         let sibling3_data = generate_node_data!(HtmlTag::Span, hash_set.clone(), HashMap::default());
         let sibling3_id = tree.push_node(&sibling3_data, Some(parent_id));
 
-        let sibling3_node = tree.get_node(&sibling3_id).unwrap();
+        let sibling3_node = &tree[&sibling3_id];
 
         assert!(matches_compound(&sequences, &tree, sibling3_node, Some(&hash_set)));
     }
@@ -1234,7 +1234,7 @@ mod tests {
         let child_data = generate_node_data!(HtmlTag::Span, HashSet::new(), HashMap::default());
         let child_id = tree.push_node(&child_data, Some(parent_id));
 
-        let child_node = tree.get_node(&child_id).unwrap();
+        let child_node = &tree[&child_id];
 
         assert!(matches_compound(&sequences, &tree, child_node, Some(&hash_set)));
     }
@@ -1270,7 +1270,7 @@ mod tests {
         let absolute_data = generate_node_data!(HtmlTag::Div, absolute_classes.clone(), absolute_attributes);
         let absolute_id = tree.push_node(&absolute_data, Some(middle_id));
 
-        let absolute_node = tree.get_node(&absolute_id).unwrap();
+        let absolute_node = &tree[&absolute_id];
 
         assert!(matches_compound(&sequences, &tree, absolute_node, Some(&absolute_classes)));
     }
@@ -1360,7 +1360,7 @@ mod tests {
         let target_data = generate_node_data!(HtmlTag::Div, HashSet::new(), HashMap::default());
         let target_id = tree.push_node(&target_data, Some(root_id));
 
-        let target_node = tree.get_node(&target_id).unwrap();
+        let target_node = &tree[&target_id];
         let classes = HashSet::new();
 
         assert!(!matches_compound(&sequences, &tree, target_node, Some(&classes)));

--- a/crates/css-selectors/src/matching.rs
+++ b/crates/css-selectors/src/matching.rs
@@ -358,9 +358,7 @@ pub fn matches_compound<H: BuildHasher>(
             return false;
         };
 
-        let Some(parent_node) = tree.get_node(&parent_id) else {
-            return false;
-        };
+        let parent_node = &tree[&parent_id];
 
         match relation {
             Combinator::Child => {
@@ -382,7 +380,7 @@ pub fn matches_compound<H: BuildHasher>(
                         }
                     }
 
-                    ancestor = candidate.parent.and_then(|id| tree.get_node(&id));
+                    ancestor = candidate.parent.map(|id| &tree[&id]);
                 }
 
                 false
@@ -397,9 +395,7 @@ pub fn matches_compound<H: BuildHasher>(
                     return false;
                 }
 
-                let Some(previous_sibling_node) = tree.get_node(&siblings[node_idx - 1]) else {
-                    return false;
-                };
+                let previous_sibling_node = &tree[&siblings[node_idx - 1]];
 
                 let Some(sibling_element) = previous_sibling_node.data.as_element() else {
                     return false;
@@ -415,9 +411,7 @@ pub fn matches_compound<H: BuildHasher>(
                 };
 
                 for sibling_id in &siblings[..node_idx] {
-                    let Some(sibling_node) = tree.get_node(sibling_id) else {
-                        continue;
-                    };
+                    let sibling_node = &tree[sibling_id];
 
                     let Some(sibling_element) = sibling_node.data.as_element() else {
                         continue;

--- a/crates/css-style/src/computed.rs
+++ b/crates/css-style/src/computed.rs
@@ -13,8 +13,8 @@ use css_values::{
 use html_dom::{DocumentRoot, NodeId};
 
 use crate::{
-    AbsoluteContext, Color4f, ComputedMaxSize, ComputedSize, Display, FontFamily, Position, RelativeContext,
-    RelativeType, clone_compute, compute, compute_px,
+    AbsoluteContext, Color4f, ComputedMaxSize, ComputedSize, Display, FontFamily, Position, RelativeType, StyleContext,
+    clone_compute, compute, compute_px,
     computed::{
         image::ComputedBackgroundImage,
         layout::{ComputedFlexBasis, ComputedGap},
@@ -123,16 +123,22 @@ impl ComputedStyle {
     pub fn from_node(
         config: &BrowserConfig,
         absolute_ctx: &AbsoluteContext,
-        relative_ctx: &mut RelativeContext,
         node_id: NodeId,
         dom: &DocumentRoot,
         rules: &Rules,
         property_registry: &mut PropertyRegistry,
+        styles: &[ComputedStyle],
     ) -> Self {
-        let parent = &relative_ctx.parent;
+        let parent_id = dom
+            .get_node(&node_id)
+            .and_then(|n| n.parent)
+            .map(|pid| pid.0)
+            .unwrap_or(0);
+        let parent = styles.get(parent_id).cloned().unwrap_or_default();
+        let mut style_ctx = StyleContext::new(&parent);
 
         let specified_style =
-            SpecifiedStyle::from_node(absolute_ctx, relative_ctx, node_id, dom, rules, property_registry);
+            SpecifiedStyle::from_node(absolute_ctx, &style_ctx, &parent, node_id, dom, rules, property_registry);
 
         let margin_top = into_compute!(specified_style, parent, margin_top);
         let margin_right = into_compute!(specified_style, parent, margin_right);
@@ -170,11 +176,11 @@ impl ComputedStyle {
         let font_size = specified_style
             .font_size
             .compute(FontSize::px(parent.font_size))
-            .to_px(Some(RelativeType::FontSize), Some(relative_ctx), absolute_ctx)
+            .to_px(Some(RelativeType::FontSize), Some(&style_ctx), absolute_ctx)
             .unwrap_or(parent.font_size);
         let float = compute!(specified_style, parent, float);
 
-        relative_ctx.font_size = font_size;
+        style_ctx.font_size = font_size;
 
         let mut computed = Self {
             align_content: compute!(specified_style, parent, align_content),
@@ -187,8 +193,8 @@ impl ComputedStyle {
                 &specified_style.background_color,
                 &specified_style.color,
                 &Color::Base(ColorBase::Transparent),
-                &relative_ctx.parent.background_color.into(),
-                relative_ctx,
+                &parent.background_color.into(),
+                &style_ctx,
                 absolute_ctx,
             ),
             background_origin: clone_compute!(specified_style, parent, background_origin),
@@ -208,39 +214,39 @@ impl ComputedStyle {
                     .background_size
                     .compute(parent.background_size.clone().into()),
                 Some(RelativeType::BackgroundArea),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             ),
             border_top_color: Color4f::from_css_color_property(
                 &specified_style.border_top_color,
                 &specified_style.color,
                 &Color::Current,
-                &relative_ctx.parent.border_top_color.into(),
-                relative_ctx,
+                &parent.border_top_color.into(),
+                &style_ctx,
                 absolute_ctx,
             ),
             border_right_color: Color4f::from_css_color_property(
                 &specified_style.border_right_color,
                 &specified_style.color,
                 &Color::Current,
-                &relative_ctx.parent.border_right_color.into(),
-                relative_ctx,
+                &parent.border_right_color.into(),
+                &style_ctx,
                 absolute_ctx,
             ),
             border_bottom_color: Color4f::from_css_color_property(
                 &specified_style.border_bottom_color,
                 &specified_style.color,
                 &Color::Current,
-                &relative_ctx.parent.border_bottom_color.into(),
-                relative_ctx,
+                &parent.border_bottom_color.into(),
+                &style_ctx,
                 absolute_ctx,
             ),
             border_left_color: Color4f::from_css_color_property(
                 &specified_style.border_left_color,
                 &specified_style.color,
                 &Color::Current,
-                &relative_ctx.parent.border_left_color.into(),
-                relative_ctx,
+                &parent.border_left_color.into(),
+                &style_ctx,
                 absolute_ctx,
             ),
             border_top_style: compute!(specified_style, parent, border_top_style),
@@ -248,32 +254,32 @@ impl ComputedStyle {
             border_bottom_style: compute!(specified_style, parent, border_bottom_style),
             border_left_style: compute!(specified_style, parent, border_left_style),
             border_top_width: compute_px!(specified_style, parent, border_top_width, BorderWidth)
-                .to_px(None, Some(relative_ctx), absolute_ctx)
+                .to_px(None, Some(&style_ctx), absolute_ctx)
                 .unwrap_or(0.0),
             border_right_width: compute_px!(specified_style, parent, border_right_width, BorderWidth)
-                .to_px(None, Some(relative_ctx), absolute_ctx)
+                .to_px(None, Some(&style_ctx), absolute_ctx)
                 .unwrap_or(0.0),
             border_bottom_width: compute_px!(specified_style, parent, border_bottom_width, BorderWidth)
-                .to_px(None, Some(relative_ctx), absolute_ctx)
+                .to_px(None, Some(&style_ctx), absolute_ctx)
                 .unwrap_or(0.0),
             border_left_width: compute_px!(specified_style, parent, border_left_width, BorderWidth)
-                .to_px(None, Some(relative_ctx), absolute_ctx)
+                .to_px(None, Some(&style_ctx), absolute_ctx)
                 .unwrap_or(0.0),
-            bottom: ComputedMargin::resolve(bottom, Some(RelativeType::ParentHeight), relative_ctx, absolute_ctx)
+            bottom: ComputedMargin::resolve(bottom, Some(RelativeType::ParentHeight), &style_ctx, absolute_ctx)
                 .unwrap_or_default(),
             clear: compute!(specified_style, parent, clear),
             color: Color4f::from_css_color_property(
                 &specified_style.color,
                 &CSSProperty::Value(Color::BLACK),
                 &Color::Base(ColorBase::Named(NamedColor::Black)),
-                &relative_ctx.parent.color.into(),
-                relative_ctx,
+                &parent.color.into(),
+                &style_ctx,
                 absolute_ctx,
             ),
             column_gap: ComputedGap::resolve(
                 specified_style.column_gap.compute(parent.column_gap.into()),
                 RelativeType::BackgroundArea,
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
@@ -282,7 +288,7 @@ impl ComputedStyle {
             flex_basis: ComputedFlexBasis::resolve(
                 specified_style.flex_basis.compute(parent.flex_basis.into()),
                 RelativeType::BackgroundArea, // TODO: flex container's inner main size
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
@@ -312,43 +318,38 @@ impl ComputedStyle {
             font_weight: specified_style
                 .font_weight
                 .compute(parent.font_weight.into()) as u16,
-            height: ComputedSize::resolve(height, RelativeType::ParentHeight, relative_ctx, absolute_ctx)
+            height: ComputedSize::resolve(height, RelativeType::ParentHeight, &style_ctx, absolute_ctx)
                 .unwrap_or_default(),
             justify_content: compute!(specified_style, parent, justify_content),
             justify_items: compute!(specified_style, parent, justify_items),
             justify_self: compute!(specified_style, parent, justify_self),
-            left: ComputedMargin::resolve(left, Some(RelativeType::ParentWidth), relative_ctx, absolute_ctx)
+            left: ComputedMargin::resolve(left, Some(RelativeType::ParentWidth), &style_ctx, absolute_ctx)
                 .unwrap_or(ComputedMargin::Auto),
-            max_height: ComputedMaxSize::resolve(max_height, RelativeType::ParentHeight, relative_ctx, absolute_ctx)
+            max_height: ComputedMaxSize::resolve(max_height, RelativeType::ParentHeight, &style_ctx, absolute_ctx)
                 .unwrap_or_default(),
             line_height: compute_px!(specified_style, parent, line_height, LineHeight)
-                .to_px(None, Some(relative_ctx), absolute_ctx)
+                .to_px(None, Some(&style_ctx), absolute_ctx)
                 .unwrap(),
-            margin_top: ComputedMargin::resolve(
-                margin_top,
-                Some(RelativeType::ParentWidth),
-                relative_ctx,
-                absolute_ctx,
-            )
-            .unwrap_or_default(),
+            margin_top: ComputedMargin::resolve(margin_top, Some(RelativeType::ParentWidth), &style_ctx, absolute_ctx)
+                .unwrap_or_default(),
             margin_right: ComputedMargin::resolve(
                 margin_right,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             margin_bottom: ComputedMargin::resolve(
                 margin_bottom,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             margin_left: ComputedMargin::resolve(
                 margin_left,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
@@ -356,48 +357,48 @@ impl ComputedStyle {
             padding_top: ComputedOffset::resolve(
                 padding_top,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             padding_right: ComputedOffset::resolve(
                 padding_right,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             padding_bottom: ComputedOffset::resolve(
                 padding_bottom,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             padding_left: ComputedOffset::resolve(
                 padding_left,
                 Some(RelativeType::ParentWidth),
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             position: compute!(specified_style, parent, position),
-            right: ComputedMargin::resolve(right, Some(RelativeType::ParentWidth), relative_ctx, absolute_ctx)
+            right: ComputedMargin::resolve(right, Some(RelativeType::ParentWidth), &style_ctx, absolute_ctx)
                 .unwrap_or(ComputedMargin::Auto),
             row_gap: ComputedGap::resolve(
                 specified_style.row_gap.compute(parent.row_gap.into()),
                 RelativeType::BackgroundArea,
-                relative_ctx,
+                &style_ctx,
                 absolute_ctx,
             )
             .unwrap_or_default(),
             text_align: compute!(specified_style, parent, text_align),
-            top: ComputedMargin::resolve(top, Some(RelativeType::ParentHeight), relative_ctx, absolute_ctx)
+            top: ComputedMargin::resolve(top, Some(RelativeType::ParentHeight), &style_ctx, absolute_ctx)
                 .unwrap_or(ComputedMargin::Auto),
             whitespace: compute!(specified_style, parent, whitespace),
-            width: ComputedSize::resolve(width, RelativeType::ParentWidth, relative_ctx, absolute_ctx)
+            width: ComputedSize::resolve(width, RelativeType::ParentWidth, &style_ctx, absolute_ctx)
                 .unwrap_or_default(),
-            max_width: ComputedMaxSize::resolve(max_width, RelativeType::ParentWidth, relative_ctx, absolute_ctx)
+            max_width: ComputedMaxSize::resolve(max_width, RelativeType::ParentWidth, &style_ctx, absolute_ctx)
                 .unwrap_or_default(),
             writing_mode: compute!(specified_style, parent, writing_mode),
             variables: Arc::clone(&specified_style.variables),

--- a/crates/css-style/src/computed.rs
+++ b/crates/css-style/src/computed.rs
@@ -129,13 +129,15 @@ impl ComputedStyle {
         property_registry: &mut PropertyRegistry,
         styles: &[ComputedStyle],
     ) -> Self {
-        let parent_id = dom[&node_id].parent.map(|pid| pid.0).unwrap_or(0);
+        let parent = match dom[&node_id].parent.and_then(|pid| styles.get(*pid)) {
+            Some(parent) => parent,
+            None => &ComputedStyle::default(),
+        };
 
-        let parent = styles.get(parent_id).cloned().unwrap_or_default();
-        let mut style_ctx = StyleContext::new(&parent);
+        let mut style_ctx = StyleContext::new(parent);
 
         let specified_style =
-            SpecifiedStyle::from_node(absolute_ctx, &style_ctx, &parent, node_id, dom, rules, property_registry);
+            SpecifiedStyle::from_node(absolute_ctx, &style_ctx, parent, node_id, dom, rules, property_registry);
 
         let margin_top = into_compute!(specified_style, parent, margin_top);
         let margin_right = into_compute!(specified_style, parent, margin_right);

--- a/crates/css-style/src/computed.rs
+++ b/crates/css-style/src/computed.rs
@@ -129,11 +129,8 @@ impl ComputedStyle {
         property_registry: &mut PropertyRegistry,
         styles: &[ComputedStyle],
     ) -> Self {
-        let parent_id = dom
-            .get_node(&node_id)
-            .and_then(|n| n.parent)
-            .map(|pid| pid.0)
-            .unwrap_or(0);
+        let parent_id = dom[&node_id].parent.map(|pid| pid.0).unwrap_or(0);
+
         let parent = styles.get(parent_id).cloned().unwrap_or_default();
         let mut style_ctx = StyleContext::new(&parent);
 

--- a/crates/css-style/src/computed/color.rs
+++ b/crates/css-style/src/computed/color.rs
@@ -7,7 +7,7 @@ use css_values::color::{
     system::SystemColor,
 };
 
-use crate::{AbsoluteContext, RelativeContext, properties::CSSProperty};
+use crate::{AbsoluteContext, StyleContext, properties::CSSProperty};
 
 /// RGBA color representation for rendering (values 0.0-1.0, sRGB gamma-encoded)
 ///
@@ -88,7 +88,7 @@ impl Color4f {
     fn from_css_color(
         color: &Color,
         text_color: &CSSProperty<Color>,
-        relative_ctx: &RelativeContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         match color {
@@ -97,8 +97,8 @@ impl Color4f {
             Color::Base(ColorBase::Function(func)) => Self::from(func.clone()),
             Color::Base(ColorBase::Transparent) => Self::TRANSPARENT,
             Color::Current => Self::resolve_current_color(text_color, absolute_ctx).map_or_else(
-                || relative_ctx.parent.color,
-                |resolved| Self::from_css_color(resolved, text_color, relative_ctx, absolute_ctx),
+                || style_ctx.parent_style.color,
+                |resolved| Self::from_css_color(resolved, text_color, style_ctx, absolute_ctx),
             ),
             Color::System(system) => Self::from(*system),
             Color::LightDark(light, dark) => {
@@ -106,7 +106,7 @@ impl Color4f {
                     ThemeCategory::Light => light.as_ref(),
                     ThemeCategory::Dark => dark.as_ref(),
                 };
-                Self::from_css_color(branch, text_color, relative_ctx, absolute_ctx)
+                Self::from_css_color(branch, text_color, style_ctx, absolute_ctx)
             }
         }
     }
@@ -117,7 +117,7 @@ impl Color4f {
         text_color: &CSSProperty<Color>,
         initial: &Color,
         parent: &Color,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         let initial = match initial {
@@ -458,22 +458,22 @@ impl From<Color4f<f64>> for Color4f<f32> {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, sync::Arc};
+    use std::net::Ipv4Addr;
 
     use url::Url;
 
     use super::*;
     use crate::ComputedStyle;
 
-    fn relative_ctx_with_parent_color(color: Color4f) -> RelativeContext {
+    fn relative_ctx_with_parent_color(color: Color4f) -> StyleContext<'static> {
         let parent = ComputedStyle {
             color,
             ..Default::default()
         };
-        RelativeContext {
-            parent: Arc::new(parent),
-            font_size: 16.0,
-        }
+
+        let parent = Box::leak(Box::new(parent));
+
+        StyleContext::new(parent)
     }
 
     #[test]

--- a/crates/css-style/src/computed/color.rs
+++ b/crates/css-style/src/computed/color.rs
@@ -117,7 +117,7 @@ impl Color4f {
         text_color: &CSSProperty<Color>,
         initial: &Color,
         parent: &Color,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         let initial = match initial {
@@ -126,7 +126,7 @@ impl Color4f {
         };
         let resolved_color = color.resolve_with_context(parent, initial);
 
-        Self::from_css_color(resolved_color, text_color, relative_ctx, absolute_ctx)
+        Self::from_css_color(resolved_color, text_color, style_ctx, absolute_ctx)
     }
 
     /// Parses a hex color string (e.g. "#RRGGBB") into an (r, g, b) tuple.
@@ -465,7 +465,7 @@ mod tests {
     use super::*;
     use crate::ComputedStyle;
 
-    fn relative_ctx_with_parent_color(color: Color4f) -> StyleContext<'static> {
+    fn style_ctx_with_parent_color(color: Color4f) -> StyleContext<'static> {
         let parent = ComputedStyle {
             color,
             ..Default::default()
@@ -480,7 +480,7 @@ mod tests {
     fn current_color_self_reference_falls_back_to_parent_color() {
         let url = Box::leak(Box::new(Url::parse(&format!("http://{}", Ipv4Addr::LOCALHOST)).unwrap()));
         let parent_color = [0.2, 0.3, 0.4, 1.0].into();
-        let relative_ctx = relative_ctx_with_parent_color(parent_color);
+        let style_ctx = style_ctx_with_parent_color(parent_color);
         let absolute_ctx = AbsoluteContext::default_url(url);
 
         let text_color = CSSProperty::Value(Color::Current);
@@ -489,7 +489,7 @@ mod tests {
             &text_color,
             &Color::Current,
             &Color::Current,
-            &relative_ctx,
+            &style_ctx,
             &absolute_ctx,
         );
 
@@ -500,7 +500,7 @@ mod tests {
     fn light_dark_current_in_light_theme_falls_back_to_parent_color() {
         let url = Box::leak(Box::new(Url::parse(&format!("http://{}", Ipv4Addr::LOCALHOST)).unwrap()));
         let parent_color = [0.1, 0.2, 0.3, 1.0].into();
-        let relative_ctx = relative_ctx_with_parent_color(parent_color);
+        let style_ctx = style_ctx_with_parent_color(parent_color);
         let absolute_ctx = AbsoluteContext {
             theme_category: ThemeCategory::Light,
             ..AbsoluteContext::default_url(url)
@@ -516,7 +516,7 @@ mod tests {
             &text_color,
             &Color::Current,
             &Color::Current,
-            &relative_ctx,
+            &style_ctx,
             &absolute_ctx,
         );
 
@@ -526,7 +526,7 @@ mod tests {
     #[test]
     fn light_dark_current_in_dark_theme_uses_dark_branch() {
         let url = Box::leak(Box::new(Url::parse(&format!("http://{}", Ipv4Addr::LOCALHOST)).unwrap()));
-        let relative_ctx = relative_ctx_with_parent_color([0.1, 0.2, 0.3, 1.0].into());
+        let style_ctx = style_ctx_with_parent_color([0.1, 0.2, 0.3, 1.0].into());
         let absolute_ctx = AbsoluteContext {
             theme_category: ThemeCategory::Dark,
             ..AbsoluteContext::default_url(url)
@@ -542,7 +542,7 @@ mod tests {
             &text_color,
             &Color::Current,
             &Color::Current,
-            &relative_ctx,
+            &style_ctx,
             &absolute_ctx,
         );
 

--- a/crates/css-style/src/computed/dimension.rs
+++ b/crates/css-style/src/computed/dimension.rs
@@ -23,13 +23,13 @@ impl ComputedSize {
     pub fn resolve(
         size: Size,
         relative_type: RelativeType,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match size {
             Size::Auto => Self::Auto,
             Size::Length(length) => {
-                let px = length.to_px(Some(relative_type), Some(relative_ctx), absolute_ctx)?;
+                let px = length.to_px(Some(relative_type), Some(style_ctx), absolute_ctx)?;
                 Self::Px(px)
             }
             Size::Percentage(p) => Self::Percentage(p.as_fraction()),
@@ -44,7 +44,7 @@ impl ComputedSize {
                         Self::default()
                     }
                 } else {
-                    let sum = expr.to_px(Some(relative_type), Some(relative_ctx), absolute_ctx)?;
+                    let sum = expr.to_px(Some(relative_type), Some(style_ctx), absolute_ctx)?;
                     Self::Px(sum)
                 }
             }
@@ -92,13 +92,13 @@ impl ComputedMaxSize {
     pub fn resolve(
         max_size: MaxSize,
         relative_type: RelativeType,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match max_size {
             MaxSize::None => Self::None,
             MaxSize::Length(length) => {
-                let px = length.to_px(Some(relative_type), Some(relative_ctx), absolute_ctx)?;
+                let px = length.to_px(Some(relative_type), Some(style_ctx), absolute_ctx)?;
                 Self::Px(px)
             }
             MaxSize::Percentage(p) => Self::Percentage(p.as_fraction()),
@@ -113,7 +113,7 @@ impl ComputedMaxSize {
                         Self::default()
                     }
                 } else {
-                    let sum = expr.to_px(Some(relative_type), Some(relative_ctx), absolute_ctx)?;
+                    let sum = expr.to_px(Some(relative_type), Some(style_ctx), absolute_ctx)?;
                     Self::Px(sum)
                 }
             }

--- a/crates/css-style/src/computed/dimension.rs
+++ b/crates/css-style/src/computed/dimension.rs
@@ -5,7 +5,7 @@ use css_values::{
     quantity::Length,
 };
 
-use crate::{AbsoluteContext, RelativeContext, RelativeType, properties::PixelRepr};
+use crate::{AbsoluteContext, RelativeType, StyleContext, properties::PixelRepr};
 
 #[derive(Debug, Clone, Default, Copy, PartialEq)]
 pub enum ComputedSize {
@@ -23,7 +23,7 @@ impl ComputedSize {
     pub fn resolve(
         size: Size,
         relative_type: RelativeType,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match size {
@@ -92,7 +92,7 @@ impl ComputedMaxSize {
     pub fn resolve(
         max_size: MaxSize,
         relative_type: RelativeType,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match max_size {

--- a/crates/css-style/src/computed/layout/flex.rs
+++ b/crates/css-style/src/computed/layout/flex.rs
@@ -1,6 +1,6 @@
 use css_values::FlexBasis;
 
-use crate::{AbsoluteContext, ComputedSize, RelativeContext, RelativeType};
+use crate::{AbsoluteContext, ComputedSize, RelativeType, StyleContext};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ComputedFlexBasis {
@@ -12,7 +12,7 @@ impl ComputedFlexBasis {
     pub fn resolve(
         flex_basis: FlexBasis,
         relative_type: RelativeType,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match flex_basis {

--- a/crates/css-style/src/computed/layout/flex.rs
+++ b/crates/css-style/src/computed/layout/flex.rs
@@ -12,14 +12,12 @@ impl ComputedFlexBasis {
     pub fn resolve(
         flex_basis: FlexBasis,
         relative_type: RelativeType,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match flex_basis {
             FlexBasis::Content => Self::Content,
-            FlexBasis::Size(size) => {
-                Self::Size(ComputedSize::resolve(size, relative_type, relative_ctx, absolute_ctx)?)
-            }
+            FlexBasis::Size(size) => Self::Size(ComputedSize::resolve(size, relative_type, style_ctx, absolute_ctx)?),
         })
     }
 }

--- a/crates/css-style/src/computed/layout/shared.rs
+++ b/crates/css-style/src/computed/layout/shared.rs
@@ -1,6 +1,6 @@
 use css_values::{Gap, calc::CalcKind, numeric::Percentage, quantity::Length};
 
-use crate::{AbsoluteContext, RelativeContext, RelativeType, properties::PixelRepr};
+use crate::{AbsoluteContext, RelativeType, StyleContext, properties::PixelRepr};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub enum ComputedGap {
@@ -14,7 +14,7 @@ impl ComputedGap {
     pub fn resolve(
         gap: Gap,
         relative_type: RelativeType,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match gap {

--- a/crates/css-style/src/computed/layout/shared.rs
+++ b/crates/css-style/src/computed/layout/shared.rs
@@ -14,12 +14,12 @@ impl ComputedGap {
     pub fn resolve(
         gap: Gap,
         relative_type: RelativeType,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match gap {
             Gap::Normal => Self::Normal,
-            Gap::Length(length) => Self::Length(length.to_px(Some(relative_type), Some(relative_ctx), absolute_ctx)?),
+            Gap::Length(length) => Self::Length(length.to_px(Some(relative_type), Some(style_ctx), absolute_ctx)?),
             Gap::Percentage(p) => Self::Percentage(p.as_fraction()),
             Gap::Calc(expr) => {
                 if expr.evaluate().is_ok() {
@@ -32,7 +32,7 @@ impl ComputedGap {
                         Self::Normal
                     }
                 } else {
-                    let sum = expr.to_px(Some(relative_type), Some(relative_ctx), absolute_ctx)?;
+                    let sum = expr.to_px(Some(relative_type), Some(style_ctx), absolute_ctx)?;
                     Self::Length(sum)
                 }
             }

--- a/crates/css-style/src/computed/offset.rs
+++ b/crates/css-style/src/computed/offset.rs
@@ -16,11 +16,11 @@ impl ComputedOffset {
     pub fn resolve(
         offset_value: OffsetValue,
         relative_type: Option<RelativeType>,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match offset_value {
-            OffsetValue::Length(len) => Self::Px(len.to_px(relative_type, Some(relative_ctx), absolute_ctx)?),
+            OffsetValue::Length(len) => Self::Px(len.to_px(relative_type, Some(style_ctx), absolute_ctx)?),
             OffsetValue::Percentage(pct) => Self::Percentage(pct.as_fraction()),
             OffsetValue::Calc(expr) => {
                 if expr.evaluate().is_ok() {
@@ -33,7 +33,7 @@ impl ComputedOffset {
                         Self::default()
                     }
                 } else {
-                    let sum = expr.to_px(relative_type, Some(relative_ctx), absolute_ctx)?;
+                    let sum = expr.to_px(relative_type, Some(style_ctx), absolute_ctx)?;
 
                     Self::Px(sum)
                 }
@@ -81,20 +81,18 @@ impl ComputedMargin {
     pub fn resolve(
         offset_value: MarginValue,
         relative_type: Option<RelativeType>,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         match offset_value {
             MarginValue::Auto => Ok(Self::Auto),
-            MarginValue::Length(len) => Ok(Self::Px(len.to_px(relative_type, Some(relative_ctx), absolute_ctx)?)),
+            MarginValue::Length(len) => Ok(Self::Px(len.to_px(relative_type, Some(style_ctx), absolute_ctx)?)),
             MarginValue::Percentage(pct) => Ok(Self::Percentage(pct.as_fraction())),
             MarginValue::Calc(expr) => {
                 let sum = expr.into_sum();
 
                 Ok(match sum.kind() {
-                    Ok(CalcKind::Length(len)) => {
-                        Self::Px(len.to_px(relative_type, Some(relative_ctx), absolute_ctx)?)
-                    }
+                    Ok(CalcKind::Length(len)) => Self::Px(len.to_px(relative_type, Some(style_ctx), absolute_ctx)?),
                     Ok(CalcKind::Percentage(p)) => Self::Percentage(p.as_fraction()),
                     _ => Self::Auto,
                 })

--- a/crates/css-style/src/computed/offset.rs
+++ b/crates/css-style/src/computed/offset.rs
@@ -4,7 +4,7 @@ use css_values::{
     numeric::Percentage,
 };
 
-use crate::{AbsoluteContext, RelativeContext, RelativeType, properties::PixelRepr};
+use crate::{AbsoluteContext, RelativeType, StyleContext, properties::PixelRepr};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ComputedOffset {
@@ -16,7 +16,7 @@ impl ComputedOffset {
     pub fn resolve(
         offset_value: OffsetValue,
         relative_type: Option<RelativeType>,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         Ok(match offset_value {
@@ -81,7 +81,7 @@ impl ComputedMargin {
     pub fn resolve(
         offset_value: MarginValue,
         relative_type: Option<RelativeType>,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         match offset_value {

--- a/crates/css-style/src/computed/position.rs
+++ b/crates/css-style/src/computed/position.rs
@@ -21,20 +21,18 @@ impl ComputedLengthPercentage {
     pub fn resolve(
         len_pct: LengthPercentage,
         relative_type: Option<RelativeType>,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         match len_pct {
-            LengthPercentage::Length(len) => {
-                Ok(Self::Px(len.to_px(relative_type, Some(relative_ctx), absolute_ctx)?))
-            }
+            LengthPercentage::Length(len) => Ok(Self::Px(len.to_px(relative_type, Some(style_ctx), absolute_ctx)?)),
             LengthPercentage::Percentage(pct) => Ok(Self::Percentage(pct.as_fraction())),
             LengthPercentage::Calc(expr) => {
                 let sum = expr.into_sum();
 
                 match sum.kind() {
                     Ok(CalcKind::Length(len)) => {
-                        let px = len.to_px(relative_type, Some(relative_ctx), absolute_ctx)?;
+                        let px = len.to_px(relative_type, Some(style_ctx), absolute_ctx)?;
                         Ok(Self::Px(px))
                     }
                     Ok(CalcKind::Percentage(p)) => Ok(Self::Percentage(p.as_fraction())),
@@ -55,13 +53,13 @@ impl ComputedWidthHeightSize {
     pub fn resolve(
         width_height_size: WidthHeightSize,
         relative_type: Option<RelativeType>,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         match width_height_size {
             WidthHeightSize::Auto => Self::Auto,
             WidthHeightSize::Length(len_pct) => {
-                match ComputedLengthPercentage::resolve(len_pct, relative_type, relative_ctx, absolute_ctx) {
+                match ComputedLengthPercentage::resolve(len_pct, relative_type, style_ctx, absolute_ctx) {
                     Ok(resolved) => Self::Length(resolved),
                     Err(_) => Self::Auto,
                 }
@@ -93,7 +91,7 @@ impl ComputedBackgroundSize {
     pub fn resolve(
         background_size: BackgroundSize,
         relative_type: Option<RelativeType>,
-        relative_ctx: &StyleContext,
+        style_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         let sizes = background_size
@@ -103,9 +101,9 @@ impl ComputedBackgroundSize {
                 Size::Cover => ComputedSize::Cover,
                 Size::Contain => ComputedSize::Contain,
                 Size::WidthHeight(width, height) => {
-                    let width = ComputedWidthHeightSize::resolve(width, relative_type, relative_ctx, absolute_ctx);
+                    let width = ComputedWidthHeightSize::resolve(width, relative_type, style_ctx, absolute_ctx);
                     let height =
-                        height.map(|h| ComputedWidthHeightSize::resolve(h, relative_type, relative_ctx, absolute_ctx));
+                        height.map(|h| ComputedWidthHeightSize::resolve(h, relative_type, style_ctx, absolute_ctx));
                     ComputedSize::WidthHeight(width, height)
                 }
             })

--- a/crates/css-style/src/computed/position.rs
+++ b/crates/css-style/src/computed/position.rs
@@ -7,7 +7,7 @@ use css_values::{
 };
 
 use crate::{
-    AbsoluteContext, RelativeContext, RelativeType,
+    AbsoluteContext, RelativeType, StyleContext,
     properties::{PixelRepr, background::BackgroundSize},
 };
 
@@ -21,7 +21,7 @@ impl ComputedLengthPercentage {
     pub fn resolve(
         len_pct: LengthPercentage,
         relative_type: Option<RelativeType>,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Result<Self, String> {
         match len_pct {
@@ -55,7 +55,7 @@ impl ComputedWidthHeightSize {
     pub fn resolve(
         width_height_size: WidthHeightSize,
         relative_type: Option<RelativeType>,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         match width_height_size {
@@ -93,7 +93,7 @@ impl ComputedBackgroundSize {
     pub fn resolve(
         background_size: BackgroundSize,
         relative_type: Option<RelativeType>,
-        relative_ctx: &RelativeContext,
+        relative_ctx: &StyleContext,
         absolute_ctx: &AbsoluteContext,
     ) -> Self {
         let sizes = background_size

--- a/crates/css-style/src/functions/math.rs
+++ b/crates/css-style/src/functions/math.rs
@@ -3,13 +3,13 @@ use css_values::{
     quantity::Dimension,
 };
 
-use crate::{AbsoluteContext, RelativeContext, RelativeType, properties::PixelRepr};
+use crate::{AbsoluteContext, RelativeType, StyleContext, properties::PixelRepr};
 
 impl PixelRepr for CalcValue {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        rel_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         match self {
@@ -54,7 +54,7 @@ impl PixelRepr for CalcProduct {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        rel_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         match self {
@@ -78,7 +78,7 @@ impl PixelRepr for CalcSum {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        rel_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         match self {
@@ -97,7 +97,7 @@ impl PixelRepr for CalcExpression {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        rel_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         self.into_sum().to_px(rel_type, rel_ctx, abs_ctx)
@@ -116,25 +116,26 @@ mod tests {
     use url::Url;
 
     /// Helper function to create test contexts
-    fn create_test_contexts() -> (RelativeContext, AbsoluteContext<'static>) {
+    fn create_test_contexts() -> (StyleContext<'static>, AbsoluteContext<'static>) {
         let url = Box::leak(Box::new(Url::parse(&format!("http://{}", Ipv4Addr::LOCALHOST)).unwrap()));
-        let rel_ctx = RelativeContext {
-            parent: ComputedStyle {
-                font_size: 16.0,
-                width: 800.0.into(),
-                height: 600.0.into(),
-                ..Default::default()
-            }
-            .into(),
+        let style = ComputedStyle {
             font_size: 16.0,
+            width: 800.0.into(),
+            height: 600.0.into(),
+            ..Default::default()
         };
+
+        let style = Box::leak(Box::new(style));
+
+        let style_ctx = StyleContext::new(style);
+
         let abs_ctx = AbsoluteContext {
             root_font_size: 16.0,
             viewport_width: 1024.0,
             viewport_height: 768.0,
             ..AbsoluteContext::default_url(url)
         };
-        (rel_ctx, abs_ctx)
+        (style_ctx, abs_ctx)
     }
 
     /// Helper function to create a number token
@@ -706,7 +707,7 @@ mod tests {
         let expr = CalcExpression::parse("calc", &input).unwrap();
         let (rel_ctx, abs_ctx) = create_test_contexts();
         let result = expr.to_px(Some(RelativeType::FontSize), Some(&rel_ctx), &abs_ctx);
-        assert_eq!(result.unwrap(), 10.0 + (2.0 * rel_ctx.parent.font_size));
+        assert_eq!(result.unwrap(), 10.0 + (2.0 * rel_ctx.parent_style.font_size));
     }
 
     #[test]

--- a/crates/css-style/src/functions/math.rs
+++ b/crates/css-style/src/functions/math.rs
@@ -9,38 +9,38 @@ impl PixelRepr for CalcValue {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&StyleContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         match self {
             Self::Number(n) => Ok(n),
             Self::Dimension(dim) => match dim {
-                Dimension::Length(l) => l.to_px(rel_type, rel_ctx, abs_ctx),
+                Dimension::Length(l) => l.to_px(rel_type, style_ctx, abs_ctx),
                 _ => Err(format!("Unsupported dimension type in calc(): {:?}", dim)),
             },
             Self::Keyword(k) => Ok(k.to_f64()),
-            Self::NestedSum(sum) => sum.to_px(rel_type, rel_ctx, abs_ctx),
-            Self::Percentage(pct) => pct.to_px(rel_type, rel_ctx, abs_ctx),
+            Self::NestedSum(sum) => sum.to_px(rel_type, style_ctx, abs_ctx),
+            Self::Percentage(pct) => pct.to_px(rel_type, style_ctx, abs_ctx),
             Self::Min(args) => Ok(args
                 .into_iter()
-                .map(|sum| sum.to_px(rel_type, rel_ctx, abs_ctx))
+                .map(|sum| sum.to_px(rel_type, style_ctx, abs_ctx))
                 .map(|res| res.unwrap_or(f64::INFINITY))
                 .fold(f64::INFINITY, f64::min)),
             Self::Max(args) => Ok(args
                 .into_iter()
-                .map(|sum| sum.to_px(rel_type, rel_ctx, abs_ctx))
+                .map(|sum| sum.to_px(rel_type, style_ctx, abs_ctx))
                 .map(|res| res.unwrap_or(f64::NEG_INFINITY))
                 .fold(f64::NEG_INFINITY, f64::max)),
             Self::Clamp(args) => {
                 let min_val = match args.min {
-                    Some(min_sum) => min_sum.to_px(rel_type, rel_ctx, abs_ctx)?,
+                    Some(min_sum) => min_sum.to_px(rel_type, style_ctx, abs_ctx)?,
                     None => f64::NEG_INFINITY,
                 };
 
-                let val_val = args.val.to_px(rel_type, rel_ctx, abs_ctx)?;
+                let val_val = args.val.to_px(rel_type, style_ctx, abs_ctx)?;
 
                 let max_val = match args.max {
-                    Some(max_sum) => max_sum.to_px(rel_type, rel_ctx, abs_ctx)?,
+                    Some(max_sum) => max_sum.to_px(rel_type, style_ctx, abs_ctx)?,
                     None => f64::INFINITY,
                 };
 
@@ -54,20 +54,20 @@ impl PixelRepr for CalcProduct {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&StyleContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         match self {
-            Self::Value(v) => v.to_px(rel_type, rel_ctx, abs_ctx),
+            Self::Value(v) => v.to_px(rel_type, style_ctx, abs_ctx),
             Self::Multiply(left, right) => {
-                Ok(left.to_px(rel_type, rel_ctx, abs_ctx)? * right.to_px(rel_type, rel_ctx, abs_ctx)?)
+                Ok(left.to_px(rel_type, style_ctx, abs_ctx)? * right.to_px(rel_type, style_ctx, abs_ctx)?)
             }
             Self::Divide(left, right) => {
-                let divisor = right.to_px(rel_type, rel_ctx, abs_ctx)?;
+                let divisor = right.to_px(rel_type, style_ctx, abs_ctx)?;
                 if divisor == 0.0 {
                     Ok(f64::NAN)
                 } else {
-                    Ok(left.to_px(rel_type, rel_ctx, abs_ctx)? / divisor)
+                    Ok(left.to_px(rel_type, style_ctx, abs_ctx)? / divisor)
                 }
             }
         }
@@ -78,16 +78,16 @@ impl PixelRepr for CalcSum {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&StyleContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         match self {
-            Self::Product(p) => p.to_px(rel_type, rel_ctx, abs_ctx),
+            Self::Product(p) => p.to_px(rel_type, style_ctx, abs_ctx),
             Self::Add(left, right) => {
-                Ok(left.to_px(rel_type, rel_ctx, abs_ctx)? + right.to_px(rel_type, rel_ctx, abs_ctx)?)
+                Ok(left.to_px(rel_type, style_ctx, abs_ctx)? + right.to_px(rel_type, style_ctx, abs_ctx)?)
             }
             Self::Subtract(left, right) => {
-                Ok(left.to_px(rel_type, rel_ctx, abs_ctx)? - right.to_px(rel_type, rel_ctx, abs_ctx)?)
+                Ok(left.to_px(rel_type, style_ctx, abs_ctx)? - right.to_px(rel_type, style_ctx, abs_ctx)?)
             }
         }
     }
@@ -97,10 +97,10 @@ impl PixelRepr for CalcExpression {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&StyleContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
-        self.into_sum().to_px(rel_type, rel_ctx, abs_ctx)
+        self.into_sum().to_px(rel_type, style_ctx, abs_ctx)
     }
 }
 
@@ -177,8 +177,8 @@ mod tests {
     fn test_simple_number() {
         let input = vec![number_token(42.0)];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 42.0);
     }
 
@@ -186,8 +186,8 @@ mod tests {
     fn test_simple_negative_number() {
         let input = vec![number_token(-42.0)];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), -42.0);
     }
 
@@ -201,8 +201,8 @@ mod tests {
             number_token(5.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 15.0);
     }
 
@@ -216,8 +216,8 @@ mod tests {
             number_token(5.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 5.0);
     }
 
@@ -235,8 +235,8 @@ mod tests {
             number_token(3.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 18.0);
     }
 
@@ -254,8 +254,8 @@ mod tests {
             number_token(3.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 12.0);
     }
 
@@ -269,8 +269,8 @@ mod tests {
             number_token(5.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 50.0);
     }
 
@@ -284,8 +284,8 @@ mod tests {
             number_token(5.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 2.0);
     }
 
@@ -299,8 +299,8 @@ mod tests {
             number_token(0.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert!(result.unwrap().is_nan());
     }
 
@@ -318,8 +318,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 20.0);
     }
 
@@ -338,8 +338,8 @@ mod tests {
         ];
 
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 16.0);
     }
 
@@ -365,8 +365,8 @@ mod tests {
             number_token(4.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 18.0);
     }
 
@@ -380,8 +380,8 @@ mod tests {
             number_token(-5.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 5.0);
     }
 
@@ -398,8 +398,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert!((result.unwrap() - (std::f64::consts::PI * 2.0)).abs() < 0.001);
     }
 
@@ -416,8 +416,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert!((result.unwrap() - (std::f64::consts::E * 2.0)).abs() < 0.001);
     }
 
@@ -434,8 +434,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx).unwrap();
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx).unwrap();
         assert!(result.is_infinite() && result.is_sign_positive());
     }
 
@@ -452,8 +452,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx).unwrap();
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx).unwrap();
         assert!(result.is_infinite() && result.is_sign_negative());
     }
 
@@ -470,8 +470,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert!(result.unwrap().is_nan());
     }
 
@@ -489,8 +489,8 @@ mod tests {
             number_token(4.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 24.0);
     }
 
@@ -508,8 +508,8 @@ mod tests {
             number_token(2.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 4.0);
     }
 
@@ -577,8 +577,8 @@ mod tests {
             number_token(-20.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 70.0);
     }
 
@@ -596,8 +596,8 @@ mod tests {
             number_token(-10.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 110.0);
     }
 
@@ -611,8 +611,8 @@ mod tests {
             number_token(-5.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), -50.0);
     }
 
@@ -620,8 +620,8 @@ mod tests {
     fn test_no_whitespace_required_for_multiply() {
         let input = vec![number_token(10.0), delim_token('*'), number_token(5.0)];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 50.0);
     }
 
@@ -629,8 +629,8 @@ mod tests {
     fn test_no_whitespace_required_for_divide() {
         let input = vec![number_token(10.0), delim_token('/'), number_token(5.0)];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 2.0);
     }
 
@@ -646,8 +646,8 @@ mod tests {
             number_token(20.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 70.0);
     }
 
@@ -690,8 +690,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 20.0);
     }
 
@@ -705,9 +705,9 @@ mod tests {
             dimension_token(2.0, "em"),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(Some(RelativeType::FontSize), Some(&rel_ctx), &abs_ctx);
-        assert_eq!(result.unwrap(), 10.0 + (2.0 * rel_ctx.parent_style.font_size));
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(Some(RelativeType::FontSize), Some(&style_ctx), &abs_ctx);
+        assert_eq!(result.unwrap(), 10.0 + (2.0 * style_ctx.parent_style.font_size));
     }
 
     #[test]
@@ -720,8 +720,8 @@ mod tests {
             dimension_token(2.0, "rem"),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(Some(RelativeType::RootFontSize), Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(Some(RelativeType::RootFontSize), Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 10.0 + (2.0 * abs_ctx.root_font_size));
     }
 
@@ -738,8 +738,8 @@ mod tests {
             }),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(Some(RelativeType::ParentWidth), Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(Some(RelativeType::ParentWidth), Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 10.0 + (0.5 * 800.0));
     }
 
@@ -753,8 +753,8 @@ mod tests {
             dimension_token(2.0, "vw"),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(Some(RelativeType::ViewportWidth), Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(Some(RelativeType::ViewportWidth), Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 10.0 + (0.02 * abs_ctx.viewport_width));
     }
 
@@ -768,8 +768,8 @@ mod tests {
             dimension_token(10.0, "vh"),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 176.8);
     }
 
@@ -787,8 +787,8 @@ mod tests {
             value: vec![number_token(100.0), comma_token(), number_token(200.0)],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -805,8 +805,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -826,8 +826,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -835,8 +835,8 @@ mod tests {
     fn test_min_expression_standalone() {
         let input = vec![number_token(100.0), comma_token(), number_token(200.0)];
         let expr = CalcExpression::parse("min", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -847,8 +847,8 @@ mod tests {
             value: vec![number_token(100.0), comma_token(), number_token(200.0)],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 200.0);
     }
 
@@ -865,8 +865,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 300.0);
     }
 
@@ -886,8 +886,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -895,8 +895,8 @@ mod tests {
     fn test_max_expression_standalone() {
         let input = vec![number_token(100.0), comma_token(), number_token(200.0)];
         let expr = CalcExpression::parse("max", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 200.0);
     }
 
@@ -915,8 +915,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 150.0);
     }
 
@@ -935,8 +935,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -955,8 +955,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 200.0);
     }
 
@@ -983,8 +983,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 200.0);
     }
 
@@ -1000,8 +1000,8 @@ mod tests {
             number_token(200.0),
         ];
         let expr = CalcExpression::parse("clamp", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 150.0);
     }
 
@@ -1053,8 +1053,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 50.0);
     }
 
@@ -1076,8 +1076,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 300.0);
     }
 
@@ -1102,8 +1102,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 42.0);
     }
 
@@ -1125,8 +1125,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 30.0);
     }
 
@@ -1145,8 +1145,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 150.0);
     }
 
@@ -1171,8 +1171,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 100.0);
     }
 
@@ -1188,8 +1188,8 @@ mod tests {
             ],
         })];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 102.4);
     }
 
@@ -1206,8 +1206,8 @@ mod tests {
             number_token(50.0),
         ];
         let expr = CalcExpression::parse("calc", &input).unwrap();
-        let (rel_ctx, abs_ctx) = create_test_contexts();
-        let result = expr.to_px(None, Some(&rel_ctx), &abs_ctx);
+        let (style_ctx, abs_ctx) = create_test_contexts();
+        let result = expr.to_px(None, Some(&style_ctx), &abs_ctx);
         assert_eq!(result.unwrap(), 150.0);
     }
 }

--- a/crates/css-style/src/handler.rs
+++ b/crates/css-style/src/handler.rs
@@ -17,7 +17,7 @@ use css_values::{
 use tracing::trace;
 
 use crate::{
-    AbsoluteContext, Offset, RelativeContext, RelativeType,
+    AbsoluteContext, Offset, RelativeType, StyleContext,
     properties::{
         CSSProperty, PixelRepr,
         background::{
@@ -32,8 +32,8 @@ use crate::{
 /// Context for updating a CSS property, containing necessary information and utilities for the update process.
 pub struct PropertyUpdateContext<'css> {
     pub absolute_ctx: &'css AbsoluteContext<'css>,
+    pub style_ctx: &'css StyleContext<'css>,
     pub specified_style: &'css mut SpecifiedStyle,
-    pub relative_ctx: &'css RelativeContext,
     pub errors: Vec<PropertyError>,
 }
 
@@ -48,13 +48,13 @@ pub struct PropertyError {
 impl<'css> PropertyUpdateContext<'css> {
     pub const fn new(
         absolute_ctx: &'css AbsoluteContext,
+        style_ctx: &'css StyleContext,
         specified_style: &'css mut SpecifiedStyle,
-        relative_ctx: &'css RelativeContext,
     ) -> Self {
         Self {
             absolute_ctx,
+            style_ctx,
             specified_style,
-            relative_ctx,
             errors: Vec::new(),
         }
     }
@@ -89,7 +89,7 @@ impl<'css> PropertyUpdateContext<'css> {
             CSSProperty::Global(_) => self
                 .specified_style
                 .writing_mode
-                .compute(self.relative_ctx.parent.writing_mode),
+                .compute(self.style_ctx.parent_style.writing_mode),
         }
     }
 
@@ -1307,7 +1307,7 @@ pub fn handle_font_size(ctx: &mut PropertyUpdateContext, stream: &mut ComponentV
     if let Ok(font_size) = CSSProperty::resolve(&ctx.specified_style.font_size) {
         ctx.specified_style.computed_font_size_px = match font_size {
             FontSize::Absolute(abs) => {
-                let Ok(px) = abs.to_px(Some(RelativeType::FontSize), Some(ctx.relative_ctx), ctx.absolute_ctx) else {
+                let Ok(px) = abs.to_px(Some(RelativeType::FontSize), Some(ctx.style_ctx), ctx.absolute_ctx) else {
                     ctx.record_error_from_stream(
                         "font-size",
                         stream,
@@ -1319,7 +1319,7 @@ pub fn handle_font_size(ctx: &mut PropertyUpdateContext, stream: &mut ComponentV
                 px
             }
             FontSize::Relative(rel) => {
-                let Ok(px) = rel.to_px(Some(RelativeType::FontSize), Some(ctx.relative_ctx), ctx.absolute_ctx) else {
+                let Ok(px) = rel.to_px(Some(RelativeType::FontSize), Some(ctx.style_ctx), ctx.absolute_ctx) else {
                     ctx.record_error_from_stream(
                         "font-size",
                         stream,
@@ -1331,7 +1331,7 @@ pub fn handle_font_size(ctx: &mut PropertyUpdateContext, stream: &mut ComponentV
                 px
             }
             FontSize::Length(len) => {
-                let Ok(px) = len.to_px(Some(RelativeType::FontSize), Some(ctx.relative_ctx), ctx.absolute_ctx) else {
+                let Ok(px) = len.to_px(Some(RelativeType::FontSize), Some(ctx.style_ctx), ctx.absolute_ctx) else {
                     ctx.record_error_from_stream(
                         "font-size",
                         stream,
@@ -1343,7 +1343,7 @@ pub fn handle_font_size(ctx: &mut PropertyUpdateContext, stream: &mut ComponentV
                 px
             }
             FontSize::Percentage(pct) => {
-                let parent_font_size = ctx.relative_ctx.parent.font_size;
+                let parent_font_size = ctx.style_ctx.parent_style.font_size;
 
                 pct.as_fraction() * parent_font_size
             }
@@ -1359,7 +1359,7 @@ pub fn handle_font_size(ctx: &mut PropertyUpdateContext, stream: &mut ComponentV
 
                 match kind {
                     CalcKind::Length(len) => {
-                        let Ok(px) = len.to_px(Some(RelativeType::FontSize), Some(ctx.relative_ctx), ctx.absolute_ctx)
+                        let Ok(px) = len.to_px(Some(RelativeType::FontSize), Some(ctx.style_ctx), ctx.absolute_ctx)
                         else {
                             ctx.record_error_from_stream(
                                 "font-size",
@@ -1374,7 +1374,7 @@ pub fn handle_font_size(ctx: &mut PropertyUpdateContext, stream: &mut ComponentV
                         px
                     }
                     CalcKind::Percentage(pct) => {
-                        let parent_font_size = ctx.relative_ctx.parent.font_size;
+                        let parent_font_size = ctx.style_ctx.parent_style.font_size;
 
                         pct.as_fraction() * parent_font_size
                     }
@@ -1402,11 +1402,11 @@ pub fn handle_font_weight(ctx: &mut PropertyUpdateContext, stream: &mut Componen
             && let CssTokenKind::Ident(ident) = &token.kind
         {
             if ident.eq_ignore_ascii_case("lighter") {
-                let lighter = ctx.relative_ctx.parent.font_weight - 100;
+                let lighter = ctx.style_ctx.parent_style.font_weight - 100;
                 ctx.specified_style.font_weight = CSSProperty::Value(FontWeight::from(lighter));
                 return;
             } else if ident.eq_ignore_ascii_case("bolder") {
-                let bolder = ctx.relative_ctx.parent.font_weight + 100;
+                let bolder = ctx.style_ctx.parent_style.font_weight + 100;
                 ctx.specified_style.font_weight = CSSProperty::Value(FontWeight::from(bolder));
                 return;
             }
@@ -1475,6 +1475,8 @@ pub fn handle_gap(ctx: &mut PropertyUpdateContext, stream: &mut ComponentValueSt
 mod tests {
     use std::net::Ipv4Addr;
 
+    use crate::ComputedStyle;
+
     use super::*;
 
     use css_cssom::CSSStyleSheet;
@@ -1487,10 +1489,16 @@ mod tests {
         AbsoluteContext::default_url(url)
     }
 
+    fn style_ctx() -> StyleContext<'static> {
+        let style = Box::leak(Box::new(ComputedStyle::default()));
+
+        StyleContext::new(style)
+    }
+
     #[test]
     fn test_border_extra_tokens() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle {
             border_top_style: CSSProperty::Value(BorderStyle::Solid),
             border_right_style: CSSProperty::Value(BorderStyle::Solid),
@@ -1504,7 +1512,7 @@ mod tests {
         let decls = CSSStyleSheet::from_inline("border: red 1px solid somethingelse;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_border(&mut ctx, &mut stream);
 
@@ -1515,13 +1523,13 @@ mod tests {
     #[test]
     fn test_border_any_order() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("border: red 1px solid;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_border(&mut ctx, &mut stream);
 
@@ -1534,13 +1542,13 @@ mod tests {
     #[test]
     fn test_border_some_missing() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("border: solid;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_border(&mut ctx, &mut stream);
 
@@ -1554,7 +1562,7 @@ mod tests {
     #[test]
     fn test_border_global_keyword() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let before = specified.clone();
@@ -1562,7 +1570,7 @@ mod tests {
         let decls = CSSStyleSheet::from_inline("border: inherit solid;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_border(&mut ctx, &mut stream);
 
@@ -1573,7 +1581,7 @@ mod tests {
     #[test]
     fn test_background_multiple_layers_with_size_and_color() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline(
@@ -1581,7 +1589,7 @@ mod tests {
         );
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_background(&mut ctx, &mut stream);
 
@@ -1666,13 +1674,13 @@ mod tests {
     #[test]
     fn test_background_repeat_two_values() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("background: none left top / cover repeat no-repeat;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_background(&mut ctx, &mut stream);
 
@@ -1698,13 +1706,13 @@ mod tests {
     #[test]
     fn test_background_origin_clip_chain_padding_border() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("background: none padding-box border-box;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_background(&mut ctx, &mut stream);
 
@@ -1730,13 +1738,13 @@ mod tests {
     #[test]
     fn test_background_zero_zero() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("background: 0 0;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_background(&mut ctx, &mut stream);
 
@@ -1766,13 +1774,13 @@ mod tests {
     #[test]
     fn test_background_none() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("background: none;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_background(&mut ctx, &mut stream);
 
@@ -1791,13 +1799,13 @@ mod tests {
     #[test]
     fn test_flex() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("flex: 1 0 auto;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_flex(&mut ctx, &mut stream);
 
@@ -1810,13 +1818,13 @@ mod tests {
     #[test]
     fn test_flex_flow() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("flex-flow: column-reverse wrap;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_flex_flow(&mut ctx, &mut stream);
 
@@ -1828,13 +1836,13 @@ mod tests {
     #[test]
     fn test_gap() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("gap: 10px 20px;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_gap(&mut ctx, &mut stream);
 
@@ -1846,13 +1854,13 @@ mod tests {
     #[test]
     fn test_flex_invalid() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("flex: 1 1 1 1;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_flex(&mut ctx, &mut stream);
 
@@ -1862,13 +1870,13 @@ mod tests {
     #[test]
     fn test_flex_flow_invalid() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("flex-flow: row unknown-wrap;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_flex_flow(&mut ctx, &mut stream);
 
@@ -1878,13 +1886,13 @@ mod tests {
     #[test]
     fn test_gap_invalid() {
         let abs = absoulte_ctx();
-        let rel = RelativeContext::default();
+        let style_ctx = style_ctx();
         let mut specified = SpecifiedStyle::default();
 
         let decls = CSSStyleSheet::from_inline("gap: invalid-gap;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_gap(&mut ctx, &mut stream);
 
@@ -1893,7 +1901,7 @@ mod tests {
         let decls = CSSStyleSheet::from_inline("gap: 10px 20px 30px;");
         let values = decls[0].original_values.clone();
         let mut stream = ComponentValueStream::from(&values);
-        let mut ctx = PropertyUpdateContext::new(&abs, &mut specified, &rel);
+        let mut ctx = PropertyUpdateContext::new(&abs, &style_ctx, &mut specified);
 
         handle_gap(&mut ctx, &mut stream);
 

--- a/crates/css-style/src/lib.rs
+++ b/crates/css-style/src/lib.rs
@@ -23,5 +23,5 @@ pub use properties::display::*;
 pub use properties::font::*;
 pub use properties::offset::*;
 pub use properties::position::*;
-pub use properties::{AbsoluteContext, RelativeContext, RelativeType};
-pub use tree::{StyleTree, StyledNode};
+pub use properties::{AbsoluteContext, RelativeType, StyleContext};
+pub use tree::StyleTree;

--- a/crates/css-style/src/properties.rs
+++ b/crates/css-style/src/properties.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use browser_preferences::theme::ThemeCategory;
 use css_cssom::ComponentValueStream;
@@ -48,8 +48,8 @@ pub trait PixelRepr: Sized {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
-        abs_ctx: &AbsoluteContext,
+        style_ctx: Option<&StyleContext>,
+        absolute_ctx: &AbsoluteContext,
     ) -> Result<f64, String>;
 }
 
@@ -120,10 +120,20 @@ impl<'page> AbsoluteContext<'page> {
 }
 
 /// Context for resolving relative CSS properties, such as percentages or 'em' units. It provides access to the parent style for inheritance and percentage calculations.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct RelativeContext {
-    pub parent: Arc<ComputedStyle>,
+#[derive(Debug, Clone, PartialEq)]
+pub struct StyleContext<'css> {
+    pub parent_style: &'css ComputedStyle,
     pub font_size: f64,
+}
+
+impl<'css> StyleContext<'css> {
+    #[must_use]
+    pub fn new(parent_style: &'css ComputedStyle) -> StyleContext<'css> {
+        Self {
+            parent_style,
+            font_size: parent_style.font_size,
+        }
+    }
 }
 
 /// A CSS property that can either be a specific value or a global value (initial, inherit, unset, revert, revert-layer).

--- a/crates/css-style/src/properties.rs
+++ b/crates/css-style/src/properties.rs
@@ -43,7 +43,7 @@ pub mod text;
 pub trait PixelRepr: Sized {
     /// Converts the value to pixels based on the provided context. The `rel_type` parameter indicates
     /// the type of relative measurement (e.g., font size, parent width) that may be needed for the conversion.
-    /// The `rel_ctx` provides access to the parent style for inheritance and percentage calculations, while
+    /// The `style_ctx` provides access to the parent style for inheritance and percentage calculations, while
     /// the `abs_ctx` provides access to absolute context values like root font size and viewport dimensions.
     fn to_px(
         self,

--- a/crates/css-style/src/properties/border.rs
+++ b/crates/css-style/src/properties/border.rs
@@ -5,14 +5,14 @@ use css_values::{border::BorderWidth, calc::CalcKind};
 
 use crate::{
     RelativeType,
-    properties::{AbsoluteContext, PixelRepr, RelativeContext},
+    properties::{AbsoluteContext, PixelRepr, StyleContext},
 };
 
 impl PixelRepr for BorderWidth {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        rel_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {

--- a/crates/css-style/src/properties/border.rs
+++ b/crates/css-style/src/properties/border.rs
@@ -12,16 +12,16 @@ impl PixelRepr for BorderWidth {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&StyleContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {
-            Self::Length(len) => len.to_px(rel_type, rel_ctx, abs_ctx)?,
+            Self::Length(len) => len.to_px(rel_type, style_ctx, abs_ctx)?,
             Self::Calc(expr) => {
                 let kind = expr.into_sum().kind();
 
                 match kind {
-                    Ok(CalcKind::Length(len)) => len.to_px(rel_type, rel_ctx, abs_ctx)?,
+                    Ok(CalcKind::Length(len)) => len.to_px(rel_type, style_ctx, abs_ctx)?,
                     _ => 0.0,
                 }
             }

--- a/crates/css-style/src/properties/font.rs
+++ b/crates/css-style/src/properties/font.rs
@@ -19,7 +19,7 @@ impl PixelRepr for AbsoluteSize {
     fn to_px(
         self,
         _rel_type: Option<RelativeType>,
-        _rel_ctx: Option<&StyleContext>,
+        _style_ctx: Option<&StyleContext>,
         _abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {

--- a/crates/css-style/src/properties/font.rs
+++ b/crates/css-style/src/properties/font.rs
@@ -12,14 +12,14 @@ use css_values::{
 
 use crate::{
     RelativeType,
-    properties::{AbsoluteContext, PixelRepr, RelativeContext},
+    properties::{AbsoluteContext, PixelRepr, StyleContext},
 };
 
 impl PixelRepr for AbsoluteSize {
     fn to_px(
         self,
         _rel_type: Option<RelativeType>,
-        _rel_ctx: Option<&RelativeContext>,
+        _rel_ctx: Option<&StyleContext>,
         _abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {
@@ -39,12 +39,12 @@ impl PixelRepr for RelativeSize {
     fn to_px(
         self,
         _rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {
-            Self::Smaller => rel_ctx.map_or(abs_ctx.root_font_size * 0.833, |ctx| ctx.parent.font_size * 0.833),
-            Self::Larger => rel_ctx.map_or(abs_ctx.root_font_size * 1.2, |ctx| ctx.parent.font_size * 1.2),
+            Self::Smaller => style_ctx.map_or(abs_ctx.root_font_size * 0.833, |ctx| ctx.parent_style.font_size * 0.833),
+            Self::Larger => style_ctx.map_or(abs_ctx.root_font_size * 1.2, |ctx| ctx.parent_style.font_size * 1.2),
         })
     }
 }
@@ -135,25 +135,25 @@ impl PixelRepr for FontSize {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {
-            Self::Absolute(abs) => abs.to_px(rel_type, rel_ctx, abs_ctx)?,
-            Self::Length(len) => len.to_px(rel_type, rel_ctx, abs_ctx)?,
+            Self::Absolute(abs) => abs.to_px(rel_type, style_ctx, abs_ctx)?,
+            Self::Length(len) => len.to_px(rel_type, style_ctx, abs_ctx)?,
             Self::Percentage(pct) => {
-                pct.as_fraction() * rel_ctx.map_or(abs_ctx.root_font_size, |ctx| ctx.parent.font_size)
+                pct.as_fraction() * style_ctx.map_or(abs_ctx.root_font_size, |ctx| ctx.parent_style.font_size)
             }
-            Self::Relative(rel) => rel.to_px(rel_type, rel_ctx, abs_ctx)?,
+            Self::Relative(rel) => rel.to_px(rel_type, style_ctx, abs_ctx)?,
             Self::Calc(expr) => {
                 let kind = expr.into_sum().kind();
 
                 match kind {
-                    Ok(CalcKind::Length(len)) => len.to_px(rel_type, rel_ctx, abs_ctx)?,
+                    Ok(CalcKind::Length(len)) => len.to_px(rel_type, style_ctx, abs_ctx)?,
                     Ok(CalcKind::Percentage(pct)) => {
-                        pct.as_fraction() * rel_ctx.map_or(abs_ctx.root_font_size, |ctx| ctx.parent.font_size)
+                        pct.as_fraction() * style_ctx.map_or(abs_ctx.root_font_size, |ctx| ctx.parent_style.font_size)
                     }
-                    _ => FontSize::Absolute(AbsoluteSize::Medium).to_px(rel_type, rel_ctx, abs_ctx)?,
+                    _ => FontSize::Absolute(AbsoluteSize::Medium).to_px(rel_type, style_ctx, abs_ctx)?,
                 }
             }
         })

--- a/crates/css-style/src/properties/length.rs
+++ b/crates/css-style/src/properties/length.rs
@@ -4,14 +4,14 @@ use css_values::quantity::{Length, LengthUnit};
 
 use crate::{
     RelativeType,
-    properties::{AbsoluteContext, PixelRepr, RelativeContext},
+    properties::{AbsoluteContext, PixelRepr, StyleContext},
 };
 
 impl PixelRepr for Length {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self.unit() {
@@ -25,15 +25,19 @@ impl PixelRepr for Length {
             LengthUnit::Vw => abs_ctx.viewport_width * self.value() / 100.0,
             LengthUnit::Vh => abs_ctx.viewport_height * self.value() / 100.0,
 
-            LengthUnit::Ch | LengthUnit::Cap => rel_ctx.map_or_else(
+            LengthUnit::Ch | LengthUnit::Cap => style_ctx.map_or_else(
                 || abs_ctx.root_font_size * 0.5 * self.value(),
-                |ctx| ctx.parent.font_size * 0.5 * self.value(),
+                |ctx| ctx.parent_style.font_size * 0.5 * self.value(),
             ),
             LengthUnit::Rem => abs_ctx.root_font_size * self.value(),
             LengthUnit::Em => match rel_type {
-                Some(RelativeType::FontSize) => rel_ctx
-                    .map_or_else(|| abs_ctx.root_font_size * self.value(), |ctx| ctx.parent.font_size * self.value()),
-                _ => rel_ctx.map_or_else(|| abs_ctx.root_font_size * self.value(), |ctx| ctx.font_size * self.value()),
+                Some(RelativeType::FontSize) => style_ctx.map_or_else(
+                    || abs_ctx.root_font_size * self.value(),
+                    |ctx| ctx.parent_style.font_size * self.value(),
+                ),
+                _ => {
+                    style_ctx.map_or_else(|| abs_ctx.root_font_size * self.value(), |ctx| ctx.font_size * self.value())
+                }
             },
             _ => self.value(), // TODO: Handle other units properly
         })

--- a/crates/css-style/src/properties/percentage.rs
+++ b/crates/css-style/src/properties/percentage.rs
@@ -1,34 +1,34 @@
 use css_values::numeric::Percentage;
 
-use crate::{AbsoluteContext, ComputedSize, RelativeContext, RelativeType, properties::PixelRepr};
+use crate::{AbsoluteContext, ComputedSize, RelativeType, StyleContext, properties::PixelRepr};
 
 impl PixelRepr for Percentage {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match rel_type {
             Some(val) => match val {
-                RelativeType::FontSize => rel_ctx
+                RelativeType::FontSize => style_ctx
                     .map_or(abs_ctx.root_font_size * self.as_fraction(), |ctx| ctx.font_size * self.as_fraction()),
                 RelativeType::ParentHeight => {
-                    let Some(rel) = rel_ctx else {
+                    let Some(ctx) = style_ctx else {
                         return Err("Percentage with ParentHeight relative type requires a RelativeContext".to_string());
                     };
 
-                    match rel.parent.height {
+                    match ctx.parent_style.height {
                         ComputedSize::Px(px) => px * self.as_fraction(),
                         _ => Err("Parent height is not a fixed pixel value, cannot resolve percentage".to_string())?,
                     }
                 }
                 RelativeType::ParentWidth => {
-                    let Some(rel) = rel_ctx else {
+                    let Some(ctx) = style_ctx else {
                         return Err("Percentage with ParentWidth relative type requires a RelativeContext".to_string());
                     };
 
-                    match rel.parent.width {
+                    match ctx.parent_style.width {
                         ComputedSize::Px(px) => px * self.as_fraction(),
                         _ => Err("Parent width is not a fixed pixel value, cannot resolve percentage".to_string())?,
                     }
@@ -37,19 +37,19 @@ impl PixelRepr for Percentage {
                 RelativeType::ViewportHeight => abs_ctx.viewport_height * self.as_fraction(),
                 RelativeType::ViewportWidth => abs_ctx.viewport_width * self.as_fraction(),
                 RelativeType::BackgroundArea => {
-                    let Some(rel) = rel_ctx else {
+                    let Some(ctx) = style_ctx else {
                         return Err(
                             "Percentage with BackgroundArea relative type requires a RelativeContext".to_string()
                         );
                     };
 
-                    let width = match rel.parent.width {
+                    let width = match ctx.parent_style.width {
                         ComputedSize::Px(px) => px,
                         _ => Err("Parent width is not a fixed pixel value, cannot resolve background area percentage"
                             .to_string())?,
                     };
 
-                    let height = match rel.parent.height {
+                    let height = match ctx.parent_style.height {
                         ComputedSize::Px(px) => px,
                         _ => {
                             Err("Parent height is not a fixed pixel value, cannot resolve background area percentage"

--- a/crates/css-style/src/properties/text.rs
+++ b/crates/css-style/src/properties/text.rs
@@ -8,29 +8,29 @@ impl PixelRepr for LineHeight {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&StyleContext>,
+        style_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {
-            Self::Normal => rel_ctx.map_or(abs_ctx.root_font_size * abs_ctx.root_line_height_multiplier, |ctx| {
+            Self::Normal => style_ctx.map_or(abs_ctx.root_font_size * abs_ctx.root_line_height_multiplier, |ctx| {
                 ctx.font_size * abs_ctx.root_line_height_multiplier
             }),
-            Self::Number(num) => rel_ctx.map_or(abs_ctx.root_font_size * num, |ctx| ctx.font_size * num),
-            Self::Length(len) => len.to_px(rel_type, rel_ctx, abs_ctx)?,
+            Self::Number(num) => style_ctx.map_or(abs_ctx.root_font_size * num, |ctx| ctx.font_size * num),
+            Self::Length(len) => len.to_px(rel_type, style_ctx, abs_ctx)?,
             Self::Percentage(pct) => {
-                rel_ctx.map_or(abs_ctx.root_font_size * pct.as_fraction(), |ctx| ctx.font_size * pct.as_fraction())
+                style_ctx.map_or(abs_ctx.root_font_size * pct.as_fraction(), |ctx| ctx.font_size * pct.as_fraction())
             }
             Self::Calc(expr) => {
                 let kind = expr.into_sum().kind();
 
                 match kind {
-                    Ok(CalcKind::Length(len)) => len.to_px(rel_type, rel_ctx, abs_ctx)?,
-                    Ok(CalcKind::Percentage(pct)) => rel_ctx
+                    Ok(CalcKind::Length(len)) => len.to_px(rel_type, style_ctx, abs_ctx)?,
+                    Ok(CalcKind::Percentage(pct)) => style_ctx
                         .map_or(abs_ctx.root_font_size * pct.as_fraction(), |ctx| ctx.font_size * pct.as_fraction()),
                     Ok(CalcKind::Number(num)) => {
-                        rel_ctx.map_or(abs_ctx.root_font_size * num, |ctx| ctx.font_size * num)
+                        style_ctx.map_or(abs_ctx.root_font_size * num, |ctx| ctx.font_size * num)
                     }
-                    _ => LineHeight::Normal.to_px(rel_type, rel_ctx, abs_ctx)?,
+                    _ => LineHeight::Normal.to_px(rel_type, style_ctx, abs_ctx)?,
                 }
             }
         })

--- a/crates/css-style/src/properties/text.rs
+++ b/crates/css-style/src/properties/text.rs
@@ -2,13 +2,13 @@
 
 use css_values::{calc::CalcKind, text::LineHeight};
 
-use crate::{AbsoluteContext, RelativeContext, RelativeType, properties::PixelRepr};
+use crate::{AbsoluteContext, RelativeType, StyleContext, properties::PixelRepr};
 
 impl PixelRepr for LineHeight {
     fn to_px(
         self,
         rel_type: Option<RelativeType>,
-        rel_ctx: Option<&RelativeContext>,
+        rel_ctx: Option<&StyleContext>,
         abs_ctx: &AbsoluteContext,
     ) -> Result<f64, String> {
         Ok(match self {

--- a/crates/css-style/src/specified.rs
+++ b/crates/css-style/src/specified.rs
@@ -104,9 +104,7 @@ impl SpecifiedStyle {
 
         let parent_variables = Arc::clone(&parent_style.variables);
 
-        let Some(node) = dom.get_node(&node_id) else {
-            return specified_style;
-        };
+        let node = &dom[node_id];
 
         let inline_declarations = node
             .data

--- a/crates/css-style/src/specified.rs
+++ b/crates/css-style/src/specified.rs
@@ -6,7 +6,7 @@ use html_dom::{DocumentRoot, NodeId};
 use tracing::debug;
 
 use crate::{
-    RelativeContext,
+    ComputedStyle, StyleContext,
     cascade::{CascadedDeclaration, cascade, cascade_variables},
     functions::variables::resolve_css_variables,
     handler::*,
@@ -93,7 +93,8 @@ impl SpecifiedStyle {
     /// Computes the `ComputedStyle` for a given node in the DOM.
     pub fn from_node(
         absolute_ctx: &AbsoluteContext,
-        relative_ctx: &RelativeContext,
+        style_ctx: &StyleContext,
+        parent_style: &ComputedStyle,
         node_id: NodeId,
         dom: &DocumentRoot,
         rules: &Rules,
@@ -101,7 +102,7 @@ impl SpecifiedStyle {
     ) -> Self {
         let mut specified_style = Self::default();
 
-        let parent_variables = Arc::clone(&relative_ctx.parent.variables);
+        let parent_variables = Arc::clone(&parent_style.variables);
 
         let Some(node) = dom.get_node(&node_id) else {
             return specified_style;
@@ -140,7 +141,7 @@ impl SpecifiedStyle {
             specified_style.variables = parent_variables;
         }
 
-        let mut ctx = PropertyUpdateContext::new(absolute_ctx, &mut specified_style, relative_ctx);
+        let mut ctx = PropertyUpdateContext::new(absolute_ctx, style_ctx, &mut specified_style);
 
         for (property, value) in properties {
             Self::resolve_property(property, value, property_registry, &mut ctx);
@@ -160,9 +161,10 @@ impl SpecifiedStyle {
         let mut declarations = vec![declaration];
 
         let mut default_style = Self::default();
-        let default_relative_ctx = RelativeContext::default();
+        let default_computed_style = ComputedStyle::default();
+        let default_style_ctx = StyleContext::new(&default_computed_style);
 
-        let mut ctx = PropertyUpdateContext::new(absolute_ctx, &mut default_style, &default_relative_ctx);
+        let mut ctx = PropertyUpdateContext::new(absolute_ctx, &default_style_ctx, &mut default_style);
 
         let properties = cascade(&mut declarations);
 

--- a/crates/css-style/src/tree.rs
+++ b/crates/css-style/src/tree.rs
@@ -4,44 +4,21 @@
 //! based on the cascade rules and the provided stylesheets.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use browser_config::BrowserConfig;
 use css_cssom::CSSStyleSheet;
 use css_values::property::PropertyDescriptor;
-use html_dom::{DocumentRoot, NodeId};
+use html_dom::DocumentRoot;
 
+use crate::ComputedStyle;
 use crate::cascade::RuleIndex;
 use crate::properties::AbsoluteContext;
 use crate::rules::{GeneratedRule, Rules};
-use crate::{ComputedStyle, RelativeContext};
 
+/// Represents the property registry, for storing the descriptors of CSS properties, parsed via the @property rule in the stylesheets.
 #[derive(Debug, Default, Clone)]
 pub struct PropertyRegistry {
     pub descriptors: HashMap<String, PropertyDescriptor>,
-}
-
-/// Represents a node in the style tree,
-///
-/// Contains the computed style for a DOM node, its tag name (if it's an element),
-/// its children, any text content (if it's a text node), and its attributes (if it's an element).
-#[derive(Debug, Clone)]
-pub struct StyledNode {
-    pub node_id: NodeId,
-    pub style: ComputedStyle,
-    pub children: Vec<Self>,
-}
-
-impl StyledNode {
-    /// Creates a new `StyledNode` with the given `node_id`. The `tag`, `style`, `children`, and `text_content` fields are initialized to their default values.
-    #[must_use]
-    pub fn new(node_id: NodeId) -> Self {
-        Self {
-            node_id,
-            style: ComputedStyle::default(),
-            children: Vec::new(),
-        }
-    }
 }
 
 /// Represents the style tree,
@@ -51,8 +28,8 @@ impl StyledNode {
 /// its children, and any text content (if it's a text node).
 #[derive(Debug, Clone, Default)]
 pub struct StyleTree {
-    /// The root nodes of the style tree.
-    pub root_nodes: Vec<StyledNode>,
+    /// The styled nodes corresponding to the DOM nodes. Accessed via the `NodeId` as the index.
+    pub nodes: Vec<ComputedStyle>,
 
     /// A registry of CSS properties, which contains the descriptors for all known CSS properties. This is used to validate and compute styles for each node in the style tree.
     pub property_registry: PropertyRegistry,
@@ -68,102 +45,32 @@ impl StyleTree {
         dom: &DocumentRoot,
         stylesheets: &[CSSStyleSheet],
     ) -> Self {
-        fn build_styled_node(
-            config: &BrowserConfig,
-            absolute_ctx: &AbsoluteContext,
-            rel_ctx: &mut RelativeContext,
-            node_id: NodeId,
-            dom: &DocumentRoot,
-            rules: &Rules,
-            property_registry: &mut PropertyRegistry,
-        ) -> StyledNode {
-            let computed_style =
-                ComputedStyle::from_node(config, absolute_ctx, rel_ctx, node_id, dom, rules, property_registry);
-
-            rel_ctx.parent = Arc::new(computed_style.clone());
-
-            let node = dom.get_node(&node_id).unwrap();
-            let saved_parent = Arc::clone(&rel_ctx.parent);
-
-            let children = node
-                .children
-                .iter()
-                .map(|&child_id| {
-                    rel_ctx.parent = Arc::clone(&saved_parent);
-                    build_styled_node(config, absolute_ctx, rel_ctx, child_id, dom, rules, property_registry)
-                })
-                .collect();
-
-            rel_ctx.parent = saved_parent;
-
-            StyledNode {
-                node_id,
-                style: computed_style,
-                children,
-            }
-        }
-
         let mut property_registry = PropertyRegistry::default();
         let rules = GeneratedRule::build(stylesheets, &mut property_registry, absolute_ctx);
         let rule_index = RuleIndex::build(&rules);
-        let mut relative_ctx = RelativeContext::default();
 
-        let root_nodes = dom
-            .root_nodes
-            .iter()
-            .map(|&root_id| {
-                build_styled_node(
-                    config,
-                    absolute_ctx,
-                    &mut relative_ctx,
-                    root_id,
-                    dom,
-                    &Rules {
-                        generated: &rules,
-                        index: &rule_index,
-                    },
-                    &mut property_registry,
-                )
-            })
-            .collect();
+        let mut nodes = Vec::with_capacity(dom.nodes.len());
+
+        for node in &dom.nodes {
+            let computed_style = ComputedStyle::from_node(
+                config,
+                absolute_ctx,
+                node.id,
+                dom,
+                &Rules {
+                    generated: &rules,
+                    index: &rule_index,
+                },
+                &mut property_registry,
+                &nodes,
+            );
+
+            nodes.push(computed_style);
+        }
 
         Self {
-            root_nodes,
+            nodes,
             property_registry,
-        }
-    }
-
-    /// Finds a `StyledNode` in the style tree by its `NodeId`. This function performs a depth-first search through the style tree
-    /// to find the node with the specified `NodeId`. If the node is found, it returns a reference to the `StyledNode`; otherwise,
-    /// it returns `None`.
-    #[must_use]
-    pub fn find_node(&self, node_id: NodeId) -> Option<&StyledNode> {
-        fn find_in_node(node: &StyledNode, node_id: NodeId) -> Option<&StyledNode> {
-            if node.node_id == node_id {
-                return Some(node);
-            }
-            for child in &node.children {
-                if let Some(found) = find_in_node(child, node_id) {
-                    return Some(found);
-                }
-            }
-            None
-        }
-
-        for root in &self.root_nodes {
-            if let Some(found) = find_in_node(root, node_id) {
-                return Some(found);
-            }
-        }
-        None
-    }
-}
-
-impl From<StyledNode> for StyleTree {
-    fn from(value: StyledNode) -> Self {
-        Self {
-            root_nodes: vec![value],
-            property_registry: PropertyRegistry::default(),
         }
     }
 }

--- a/crates/css-style/src/tree.rs
+++ b/crates/css-style/src/tree.rs
@@ -47,7 +47,7 @@ impl StyleTree {
         let rules = GeneratedRule::build(stylesheets, &mut property_registry, absolute_ctx);
         let rule_index = RuleIndex::build(&rules);
 
-        let mut nodes = Vec::with_capacity(dom.nodes.len());
+        let mut styles = Vec::with_capacity(dom.nodes.len());
 
         for node in &dom.nodes {
             let computed_style = ComputedStyle::from_node(
@@ -60,13 +60,13 @@ impl StyleTree {
                     index: &rule_index,
                 },
                 &mut property_registry,
-                &nodes,
+                &styles,
             );
 
-            nodes.push(computed_style);
+            styles.push(computed_style);
         }
 
-        Self { nodes }
+        Self { nodes: styles }
     }
 
     pub fn total_nodes(&self) -> usize {

--- a/crates/css-style/src/tree.rs
+++ b/crates/css-style/src/tree.rs
@@ -4,11 +4,12 @@
 //! based on the cascade rules and the provided stylesheets.
 
 use std::collections::HashMap;
+use std::ops::Index;
 
 use browser_config::BrowserConfig;
 use css_cssom::CSSStyleSheet;
 use css_values::property::PropertyDescriptor;
-use html_dom::DocumentRoot;
+use html_dom::{DocumentRoot, NodeId};
 
 use crate::ComputedStyle;
 use crate::cascade::RuleIndex;
@@ -29,10 +30,7 @@ pub struct PropertyRegistry {
 #[derive(Debug, Clone, Default)]
 pub struct StyleTree {
     /// The styled nodes corresponding to the DOM nodes. Accessed via the `NodeId` as the index.
-    pub nodes: Vec<ComputedStyle>,
-
-    /// A registry of CSS properties, which contains the descriptors for all known CSS properties. This is used to validate and compute styles for each node in the style tree.
-    pub property_registry: PropertyRegistry,
+    nodes: Vec<ComputedStyle>,
 }
 
 impl StyleTree {
@@ -68,9 +66,36 @@ impl StyleTree {
             nodes.push(computed_style);
         }
 
-        Self {
-            nodes,
-            property_registry,
-        }
+        Self { nodes }
+    }
+
+    pub fn total_nodes(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn get(&self, node_id: NodeId) -> Option<&ComputedStyle> {
+        self.nodes.get(*node_id)
+    }
+}
+
+impl From<Vec<ComputedStyle>> for StyleTree {
+    fn from(nodes: Vec<ComputedStyle>) -> Self {
+        Self { nodes }
+    }
+}
+
+impl Index<NodeId> for StyleTree {
+    type Output = ComputedStyle;
+
+    fn index(&self, index: NodeId) -> &Self::Output {
+        &self.nodes[*index]
+    }
+}
+
+impl Index<&NodeId> for StyleTree {
+    type Output = ComputedStyle;
+
+    fn index(&self, index: &NodeId) -> &Self::Output {
+        &self.nodes[**index]
     }
 }

--- a/crates/html-dom/src/builder.rs
+++ b/crates/html-dom/src/builder.rs
@@ -98,13 +98,13 @@ impl<C: Collector + Default> DomTreeBuilder<C> {
     /// * `new_tag` - A reference to the `HtmlTag` representing the new tag being processed.
     fn handle_auto_close(&mut self, new_tag: &Tag) {
         let should_pop = if let Some(last_id) = self.open_elements.last() {
-            self.dom_tree.get_node(last_id).is_some_and(|node| {
-                if let NodeData::Element(elem) = &node.data {
-                    elem.tag.should_auto_close(new_tag)
-                } else {
-                    false
-                }
-            })
+            let last_node = &self.dom_tree[last_id];
+
+            if let NodeData::Element(elem) = &last_node.data {
+                elem.tag.should_auto_close(new_tag)
+            } else {
+                false
+            }
         } else {
             false
         };
@@ -167,14 +167,14 @@ impl<C: Collector + Default> DomTreeBuilder<C> {
     fn handle_end_tag(&mut self, token: &Token) {
         let target_tag = Tag::from_str_insensitive(&token.data);
 
-        let should_close = if let Some(last) = self.open_elements.last() {
-            self.dom_tree.get_node(last).is_some_and(|node| {
-                if let NodeData::Element(elem) = &node.data {
-                    elem.tag == target_tag
-                } else {
-                    false
-                }
-            })
+        let should_close = if let Some(last_id) = self.open_elements.last() {
+            let last_node = &self.dom_tree[last_id];
+
+            if let NodeData::Element(elem) = &last_node.data {
+                elem.tag == target_tag
+            } else {
+                false
+            }
         } else {
             false
         };
@@ -191,21 +191,22 @@ impl<C: Collector + Default> DomTreeBuilder<C> {
     fn handle_text_content(&mut self, token: Token) {
         let text_content = decode_html_entities(&token.data);
 
-        if let Some(last_id) = self.open_elements.last()
-            && let Some(parent_node) = self.dom_tree.get_node(last_id)
-            && let NodeData::Element(parent_elem) = &parent_node.data
-        {
-            let tag = &parent_elem.tag.clone();
-            let attributes = &parent_elem.attributes.clone();
-            let text_data = NodeData::Text(text_content.trim().to_string());
-            let new_id = self.insert_node(&text_data);
+        if let Some(last_id) = self.open_elements.last() {
+            let parent_node = &self.dom_tree[last_id];
 
-            self.collector.collect(&TagInfo {
-                tag,
-                attributes,
-                node_id: new_id,
-                data: text_data.as_text(),
-            });
+            if let NodeData::Element(parent_elem) = &parent_node.data {
+                let tag = &parent_elem.tag.clone();
+                let attributes = &parent_elem.attributes.clone();
+                let text_data = NodeData::Text(text_content.trim().to_string());
+                let new_id = self.insert_node(&text_data);
+
+                self.collector.collect(&TagInfo {
+                    tag,
+                    attributes,
+                    node_id: new_id,
+                    data: text_data.as_text(),
+                });
+            }
         }
     }
 }

--- a/crates/html-dom/src/dom.rs
+++ b/crates/html-dom/src/dom.rs
@@ -2,12 +2,27 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter},
     io::Write,
+    ops::{Deref, Index, IndexMut},
 };
 
 use crate::tag::Tag;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct NodeId(pub usize);
+
+impl From<usize> for NodeId {
+    fn from(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+impl Deref for NodeId {
+    type Target = usize;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl Display for NodeId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -169,25 +184,20 @@ impl DocumentRoot {
         self.nodes.get(node_id.0)
     }
 
-    #[must_use]
-    pub fn get_node_mut(&mut self, node_id: &NodeId) -> Option<&mut DomNode> {
-        self.nodes.get_mut(node_id.0)
-    }
-
     /// Walk up the DOM tree from the given node, returning all ancestor nodes
     /// (parent, grandparent, etc.) in order from nearest to farthest.
     #[must_use]
-    pub fn ancestors(&self, node_id: &NodeId) -> Vec<&DomNode> {
+    pub fn ancestors(&self, node: &DomNode) -> Vec<&DomNode> {
         let mut result = Vec::new();
-        let mut current = self.get_node(node_id).and_then(|n| n.parent);
+        let mut current = node.parent;
+
         while let Some(pid) = current {
-            if let Some(parent_node) = self.get_node(&pid) {
-                result.push(parent_node);
-                current = parent_node.parent;
-            } else {
-                break;
-            }
+            let parent_node = &self[pid];
+
+            result.push(parent_node);
+            current = parent_node.parent;
         }
+
         result
     }
 
@@ -203,9 +213,8 @@ impl DocumentRoot {
         self.nodes.push(new_node);
 
         if let Some(parent_id) = parent {
-            if let Some(parent_node) = self.get_node_mut(&parent_id) {
-                parent_node.children.push(node_id);
-            }
+            let parent_node = &mut self[&parent_id];
+            parent_node.children.push(node_id);
         } else {
             self.root_nodes.push(node_id);
         }
@@ -222,7 +231,7 @@ impl DocumentRoot {
     /// Used for debugging and visualization purposes.
     #[must_use]
     pub fn to_html(&self) -> Vec<u8> {
-        fn node_to_html(mut html: &mut Vec<u8>, node: &DomNode, dom: &DocumentRoot, depth: usize) {
+        fn node_to_html(mut html: &mut Vec<u8>, node: &DomNode, dom_tree: &DocumentRoot, depth: usize) {
             if node.data.as_text().is_some_and(|t| t.trim().is_empty()) {
                 return; // Skip empty text nodes
             }
@@ -259,9 +268,7 @@ impl DocumentRoot {
                     let has_child = !node.children.is_empty();
 
                     for child_id in &node.children {
-                        if let Some(child_node) = dom.get_node(child_id) {
-                            node_to_html(html, child_node, dom, depth + 1);
-                        }
+                        node_to_html(html, &dom_tree[child_id], dom_tree, depth + 1);
                     }
 
                     if has_child {
@@ -289,9 +296,7 @@ impl DocumentRoot {
         writeln!(&mut html, "<html><head></head><body>").unwrap();
 
         for root_id in &self.root_nodes {
-            if let Some(root_node) = self.get_node(root_id) {
-                node_to_html(&mut html, root_node, self, 0);
-            }
+            node_to_html(&mut html, &self[root_id], self, 0);
         }
 
         writeln!(&mut html, "</body></html>").unwrap();
@@ -299,9 +304,31 @@ impl DocumentRoot {
     }
 }
 
+impl Index<NodeId> for DocumentRoot {
+    type Output = DomNode;
+
+    fn index(&self, index: NodeId) -> &Self::Output {
+        &self.nodes[*index]
+    }
+}
+
+impl Index<&NodeId> for DocumentRoot {
+    type Output = DomNode;
+
+    fn index(&self, index: &NodeId) -> &Self::Output {
+        &self.nodes[**index]
+    }
+}
+
+impl IndexMut<&NodeId> for DocumentRoot {
+    fn index_mut(&mut self, index: &NodeId) -> &mut Self::Output {
+        &mut self.nodes[**index]
+    }
+}
+
 impl Display for DocumentRoot {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        fn fmt_node(node: &DomNode, doc: &DocumentRoot, f: &mut Formatter<'_>, indent: usize) -> std::fmt::Result {
+        fn fmt_node(node: &DomNode, dom_tree: &DocumentRoot, f: &mut Formatter<'_>, indent: usize) -> std::fmt::Result {
             match &node.data {
                 NodeData::Element(elem) => {
                     for _ in 0..indent {
@@ -324,9 +351,7 @@ impl Display for DocumentRoot {
                     }
 
                     for child_id in &node.children {
-                        if let Some(child_node) = doc.get_node(child_id) {
-                            fmt_node(child_node, doc, f, indent + 1)?;
-                        }
+                        fmt_node(&dom_tree[child_id], dom_tree, f, indent + 1)?;
                     }
 
                     for _ in 0..indent {
@@ -351,9 +376,7 @@ impl Display for DocumentRoot {
         }
 
         for root_id in &self.root_nodes {
-            if let Some(root_node) = self.get_node(root_id) {
-                fmt_node(root_node, self, f, 0)?;
-            }
+            fmt_node(&self[root_id], self, f, 0)?;
         }
 
         Ok(())

--- a/crates/layout/benches/layout_integration_benchmark.rs
+++ b/crates/layout/benches/layout_integration_benchmark.rs
@@ -192,7 +192,7 @@ fn bench_layout_pipeline(c: &mut Criterion) {
         |b, (dom, stylesheets)| {
             b.iter(|| {
                 let style_tree = build_style_tree(black_box(dom), black_box(stylesheets), viewport);
-                black_box(style_tree.root_nodes.len());
+                black_box(style_tree.total_nodes());
             })
         },
     );
@@ -200,9 +200,9 @@ fn bench_layout_pipeline(c: &mut Criterion) {
 
     let mut layout_text_context = new_text_context();
     let mut layout_group = c.benchmark_group(format!("layout/compute_layout/{fixture_name}"));
-    layout_group.throughput(Throughput::Elements(style_tree.root_nodes.len() as u64));
+    layout_group.throughput(Throughput::Elements(style_tree.total_nodes() as u64));
     layout_group.bench_with_input(
-        BenchmarkId::new("root_nodes", style_tree.root_nodes.len()),
+        BenchmarkId::new("root_nodes", style_tree.total_nodes()),
         &style_tree,
         |b, style_tree| {
             b.iter(|| {

--- a/crates/layout/benches/layout_integration_benchmark.rs
+++ b/crates/layout/benches/layout_integration_benchmark.rs
@@ -127,16 +127,8 @@ fn parse_html_and_collect_styles(
                 }
                 BlockedReason::WaitingForScript { script } => match script {
                     // TODO: When JS is supported, fix this.
-                    Script::External { src, .. } => {
-                        panic!("parser blocked on external script: {}", src);
-                    }
-                    Script::Inline {
-                        data,
-                        type_attr: mime_type,
-                    } => {
-                        let script_content = data.expect("failed to extract inline script content");
-                        panic!("parser blocked on inline script (mime_type={}): {}", mime_type, script_content);
-                    }
+                    Script::External { .. } => {}
+                    Script::Inline { .. } => {}
                 },
                 BlockedReason::WaitingForResource(_, _, _) => {}
                 BlockedReason::SVGContent { data } => {

--- a/crates/layout/src/engine.rs
+++ b/crates/layout/src/engine.rs
@@ -1,4 +1,4 @@
-use css_style::{ComputedStyle, Display, Position, StyleTree, StyledNode};
+use css_style::{ComputedStyle, Display, Position, StyleTree};
 use css_values::display::{InsideDisplay, OutsideDisplay};
 use html_dom::{DocumentRoot, NodeId};
 
@@ -27,16 +27,16 @@ pub(crate) enum LayoutMode {
 }
 
 impl LayoutMode {
-    pub fn new(styled_node: &StyledNode) -> Option<Self> {
-        if styled_node.style.display.is_none() {
+    pub fn new(style: &ComputedStyle) -> Option<Self> {
+        if style.display.is_none() {
             return None;
         }
 
-        if styled_node.style.position.is_out_of_flow() {
+        if style.position.is_out_of_flow() {
             return Some(Self::Block);
         }
 
-        if let Display::Normal { outside, inside } = styled_node.style.display {
+        if let Display::Normal { outside, inside } = style.display {
             if let Some(val) = inside {
                 match val {
                     InsideDisplay::Flex => return Some(Self::Flex),
@@ -83,12 +83,12 @@ impl LayoutEngine {
         let mut max_width = 0.0f64;
         let mut root_nodes = Vec::new();
 
-        for styled_node in &style_tree.root_nodes {
+        for node_id in &dom_tree.root_nodes {
             ctx.block_cursor.y = total_height;
 
             let pos_count_before = ctx.position_ctx().position_count();
 
-            let Some(mut node) = Self::layout_node(dom_tree, styled_node, &mut ctx, text_ctx) else {
+            let Some(mut node) = Self::layout_node(dom_tree, style_tree, node_id, &mut ctx, text_ctx) else {
                 continue;
             };
 
@@ -109,7 +109,7 @@ impl LayoutEngine {
 
         for mut defered_node in ctx
             .position_ctx()
-            .resolve_all(dom_tree, image_ctx, text_ctx)
+            .resolve_all(dom_tree, style_tree, image_ctx, text_ctx)
         {
             Self::offset_children_y(&mut defered_node.children, defered_node.margin.top.to_px());
 
@@ -138,18 +138,22 @@ impl LayoutEngine {
     /// Compute layout for a single node and its descendants
     pub(crate) fn layout_node(
         dom_tree: &DocumentRoot,
-        styled_node: &StyledNode,
+        style_tree: &StyleTree,
+        node_id: &NodeId,
         ctx: &mut LayoutContext,
         text_ctx: &mut TextContext,
     ) -> Option<LayoutNode> {
-        let _layout_mode = LayoutMode::new(styled_node)?;
+        let style = &style_tree[node_id];
+        let _layout_mode = LayoutMode::new(style)?;
 
-        BlockLayout::layout(dom_tree, styled_node, ctx, text_ctx)
+        BlockLayout::layout(node_id, dom_tree, style_tree, ctx, text_ctx)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_nodes(
         dom_tree: &DocumentRoot,
-        styled_nodes: &[&StyledNode],
+        style_tree: &StyleTree,
+        node_ids: &[NodeId],
         mode: LayoutMode,
         parent_style: &ComputedStyle,
         containing_block: Rect,
@@ -161,13 +165,14 @@ impl LayoutEngine {
                 let inline_items = InlineLayout::collect_inline_items_from_nodes(
                     containing_block,
                     dom_tree,
+                    style_tree,
                     parent_style,
-                    styled_nodes,
+                    node_ids,
                     ctx.image_ctx(),
                 );
                 let inline_ctx = InlineContext::new(containing_block);
 
-                InlineLayout::layout(dom_tree, &inline_items, ctx, text_ctx, inline_ctx)
+                InlineLayout::layout(dom_tree, style_tree, &inline_items, ctx, text_ctx, inline_ctx)
             }
             _ => todo!("Only inline layout is supported for collections of nodes right now"),
         }
@@ -186,11 +191,9 @@ impl LayoutEngine {
         text_ctx: &mut TextContext,
         image_ctx: &ImageContext,
     ) {
-        let ancestors: Vec<NodeId> = dom_tree
-            .ancestors(&node_id)
-            .into_iter()
-            .map(|n| n.id)
-            .collect();
+        let node = &dom_tree[node_id];
+
+        let ancestors: Vec<NodeId> = dom_tree.ancestors(node).into_iter().map(|n| n.id).collect();
 
         let Some(&dirty_parent_id) = ancestors.first() else {
             return;
@@ -202,15 +205,11 @@ impl LayoutEngine {
         let old_layout = layout_tree.node_at(&parent_path).unwrap();
         let old_height = old_layout.dimensions.height;
 
-        let Some(styled_node) = style_tree.find_node(dirty_parent_id) else {
-            return;
-        };
-
         let mut position_ctx = PositionContext::new(viewport);
         let mut ctx = LayoutContext::new(old_layout.dimensions, image_ctx, &mut position_ctx);
         ctx.position_ctx().update_viewport(viewport);
 
-        let Some(mut new_node) = Self::layout_node(dom_tree, styled_node, &mut ctx, text_ctx) else {
+        let Some(mut new_node) = Self::layout_node(dom_tree, style_tree, &dirty_parent_id, &mut ctx, text_ctx) else {
             return;
         };
 
@@ -261,31 +260,38 @@ impl LayoutEngine {
         }
     }
 
-    pub(crate) fn collect_children<'node, F>(
+    pub(crate) fn collect_children<F>(
         ctx: &mut LayoutContext,
-        parent_node: &'node StyledNode,
+        dom_tree: &DocumentRoot,
+        style_tree: &StyleTree,
+        parent_id: &NodeId,
         start_idx: &mut usize,
         condition: F,
-    ) -> Vec<&'node StyledNode>
+    ) -> Vec<NodeId>
     where
-        F: Fn(&StyledNode) -> bool,
+        F: Fn(&NodeId) -> bool,
     {
         let mut collected = Vec::new();
-        for child in parent_node.children.iter().skip(*start_idx) {
-            if child.style.position.is_out_of_flow() && !ctx.is_deferred() {
-                let containing_block = if child.style.position == Position::Fixed {
+        let parent_node = &dom_tree[parent_id];
+        let children = &parent_node.children;
+
+        for child in children.iter().skip(*start_idx) {
+            let style = &style_tree[child];
+
+            if style.position.is_out_of_flow() && !ctx.is_deferred() {
+                let containing_block = if style.position == Position::Fixed {
                     ctx.containing_block()
                 } else {
                     ctx.positioned_containing_block()
                 };
 
-                ctx.position_ctx().defer(child.clone(), containing_block);
+                ctx.position_ctx().defer(child, containing_block);
                 *start_idx += 1;
                 continue;
             }
 
             if condition(child) {
-                collected.push(child);
+                collected.push(*child);
                 *start_idx += 1;
             } else {
                 break;
@@ -298,9 +304,11 @@ impl LayoutEngine {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+
     use css_style::{ComputedStyle, Display};
     use css_values::display::{BoxDisplay, OutsideDisplay};
-    use html_dom::NodeId;
+    use html_dom::{DomNode, Element, HtmlTag, NodeData, NodeId, Tag};
 
     use super::*;
 
@@ -310,86 +318,81 @@ mod tests {
 
     #[test]
     fn test_layout_mode_none() {
-        let styled_node = StyledNode {
-            style: ComputedStyle {
-                display: Display::Box(BoxDisplay::None),
-                ..Default::default()
-            },
-            ..StyledNode::new(NodeId(0))
+        let style = ComputedStyle {
+            display: Display::Box(BoxDisplay::None),
+            ..Default::default()
         };
 
-        assert_eq!(LayoutMode::new(&styled_node), None);
+        assert_eq!(LayoutMode::new(&style), None);
     }
 
     #[test]
     fn test_layout_mode_block() {
-        let styled_node = StyledNode {
-            style: ComputedStyle {
-                display: Display::from(OutsideDisplay::Block),
-                ..Default::default()
-            },
-            ..StyledNode::new(NodeId(0))
+        let style = ComputedStyle {
+            display: Display::from(OutsideDisplay::Block),
+            ..Default::default()
         };
 
-        assert_eq!(LayoutMode::new(&styled_node), Some(LayoutMode::Block));
+        assert_eq!(LayoutMode::new(&style), Some(LayoutMode::Block));
     }
 
     #[test]
     fn test_layout_mode_inline() {
-        let styled_node = StyledNode {
-            style: ComputedStyle {
-                display: Display::from(OutsideDisplay::Inline),
-                ..Default::default()
-            },
-            ..StyledNode::new(NodeId(0))
+        let style = ComputedStyle {
+            display: Display::from(OutsideDisplay::Inline),
+            ..Default::default()
         };
-        assert_eq!(LayoutMode::new(&styled_node), Some(LayoutMode::Inline));
+
+        assert_eq!(LayoutMode::new(&style), Some(LayoutMode::Inline));
     }
 
     #[test]
     fn test_layout_mode_flex() {
-        let styled_node = StyledNode {
-            style: ComputedStyle {
-                display: Display::from(InsideDisplay::Flex),
-                ..Default::default()
-            },
-            ..StyledNode::new(NodeId(0))
+        let style = ComputedStyle {
+            display: Display::from(InsideDisplay::Flex),
+            ..Default::default()
         };
-        assert_eq!(LayoutMode::new(&styled_node), Some(LayoutMode::Flex));
+
+        assert_eq!(LayoutMode::new(&style), Some(LayoutMode::Flex));
     }
 
     #[test]
     fn test_layout_mode_grid() {
-        let styled_node = StyledNode {
-            style: ComputedStyle {
-                display: Display::from(InsideDisplay::Grid),
-                ..Default::default()
-            },
-            ..StyledNode::new(NodeId(0))
+        let style = ComputedStyle {
+            display: Display::from(InsideDisplay::Grid),
+            ..Default::default()
         };
-        assert_eq!(LayoutMode::new(&styled_node), Some(LayoutMode::Grid));
+
+        assert_eq!(LayoutMode::new(&style), Some(LayoutMode::Grid));
     }
 
     #[test]
     fn test_layout_empty() {
-        let styled_node = StyledNode {
-            style: ComputedStyle {
-                display: Display::from(OutsideDisplay::Block),
-                ..Default::default()
-            },
-            ..StyledNode::new(NodeId(0))
+        let style = ComputedStyle {
+            display: Display::from(OutsideDisplay::Block),
+            ..Default::default()
         };
+
+        let style_tree = StyleTree::from(vec![style]);
 
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let mut ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
         let mut text_ctx = TextContext::default();
-        let dom_tree = DocumentRoot::default();
+        let dom_tree = DocumentRoot {
+            nodes: vec![DomNode {
+                id: NodeId(0),
+                data: NodeData::Element(Element::new(Tag::Html(HtmlTag::Html), HashSet::new(), HashMap::new())),
+                children: vec![],
+                parent: None,
+            }],
+            root_nodes: vec![NodeId(0)],
+        };
 
-        let layout_node = BlockLayout::layout(&dom_tree, &styled_node, &mut ctx, &mut text_ctx).unwrap();
+        let layout_node = BlockLayout::layout(&NodeId(0), &dom_tree, &style_tree, &mut ctx, &mut text_ctx).unwrap();
 
-        assert_eq!(layout_node.node_id, styled_node.node_id);
+        assert_eq!(layout_node.node_id, NodeId(0));
         assert_eq!(layout_node.dimensions.x, 0.0);
         assert_eq!(layout_node.dimensions.y, 0.0);
         assert_eq!(layout_node.dimensions.width, 800.0);

--- a/crates/layout/src/layout.rs
+++ b/crates/layout/src/layout.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use cosmic_text::Buffer;
-use css_style::{Color4f, ComputedStyle, Position, StyledNode};
+use css_style::{Color4f, ComputedStyle, Position};
 use css_values::cursor::Cursor;
 use html_dom::NodeId;
 
@@ -81,18 +81,6 @@ impl From<&ComputedStyle> for LayoutColors {
                 left: style.border_left_color,
             },
         }
-    }
-}
-
-impl From<&Box<ComputedStyle>> for LayoutColors {
-    fn from(style: &Box<ComputedStyle>) -> Self {
-        Self::from(style.as_ref())
-    }
-}
-
-impl From<&StyledNode> for LayoutColors {
-    fn from(styled_node: &StyledNode) -> Self {
-        Self::from(&styled_node.style)
     }
 }
 

--- a/crates/layout/src/mode/block.rs
+++ b/crates/layout/src/mode/block.rs
@@ -1,6 +1,6 @@
-use css_style::{ComputedSize, ComputedStyle, Position, StyledNode};
+use css_style::{ComputedSize, ComputedStyle, Position, StyleTree};
 use css_values::display::{Clear, Float};
-use html_dom::DocumentRoot;
+use html_dom::{DocumentRoot, NodeId};
 
 use crate::{
     LayoutColors, LayoutEngine, LayoutNode, Margin, Rect, TextContext, engine::LayoutMode, layout::LayoutContext,
@@ -88,38 +88,41 @@ pub struct BlockLayout;
 
 impl BlockLayout {
     pub fn layout(
+        node_id: &NodeId,
         dom_tree: &DocumentRoot,
-        styled_node: &StyledNode,
+        style_tree: &StyleTree,
         ctx: &mut LayoutContext,
         text_ctx: &mut TextContext,
     ) -> Option<LayoutNode> {
-        if styled_node.style.position.is_out_of_flow() && !ctx.is_deferred() {
-            let containing_block = if styled_node.style.position == Position::Fixed {
+        let style = &style_tree[node_id];
+        let node = &dom_tree[node_id];
+        let node_children = &node.children;
+
+        if style.position.is_out_of_flow() && !ctx.is_deferred() {
+            let containing_block = if style.position == Position::Fixed {
                 ctx.containing_block()
             } else {
                 ctx.positioned_containing_block()
             };
-            ctx.position_ctx()
-                .defer(styled_node.clone(), containing_block);
+            ctx.position_ctx().defer(node_id, containing_block);
 
             return None;
         }
 
         let container_width = ctx.containing_block().width;
 
-        let (margin, padding, border) = PropertyResolver::resolve_box_model(&styled_node.style, container_width);
+        let (margin, padding, border) = PropertyResolver::resolve_box_model(style, container_width);
 
-        let width = Self::calculate_width(styled_node, container_width, &padding, &border);
-        let x = Self::calculate_x(styled_node, ctx, &margin, &padding, &border, width);
-        let y = Self::calculate_y(styled_node, ctx);
+        let width = Self::calculate_width(style, container_width, &padding, &border);
+        let x = Self::calculate_x(style, ctx, &margin, &padding, &border, width);
+        let y = Self::calculate_y(style, ctx);
 
-        let mut children = Vec::with_capacity(styled_node.children.len());
-        let mut flow = BlockFlow::new(&styled_node.style, container_width);
-        let child_containing_height = Self::calculate_height(styled_node, ctx.containing_block().height);
+        let mut flow = BlockFlow::new(style, container_width);
+        let child_containing_height = Self::calculate_height(style, ctx.containing_block().height);
 
         let parent_positioned_cb = ctx.positioned_containing_block();
 
-        if styled_node.style.position == Position::Static {
+        if style.position == Position::Static {
             ctx.set_positioned_containing_block(parent_positioned_cb);
         } else {
             let rect = Rect::new(x, y, width, child_containing_height + padding.vertical() + border.vertical());
@@ -128,14 +131,20 @@ impl BlockLayout {
             ctx.set_positioned_containing_block(rect);
         }
 
-        let child_len = styled_node.children.len();
+        let mut children = Vec::with_capacity(node_children.len());
+        let child_len = node_children.len();
         let mut child_idx = 0;
 
         while child_idx < child_len {
-            let child_style_node = &styled_node.children[child_idx];
+            let child_style_node_id = &node_children[child_idx];
+            let child_style = &style_tree[child_style_node_id];
 
-            if Self::is_inline(child_style_node) {
-                let inline_items = LayoutEngine::collect_children(ctx, styled_node, &mut child_idx, Self::is_inline);
+            if Self::is_inline(child_style) {
+                let inline_items =
+                    LayoutEngine::collect_children(ctx, dom_tree, style_tree, node_id, &mut child_idx, |node_id| {
+                        let style = &style_tree[node_id];
+                        Self::is_inline(style)
+                    });
 
                 let containing_block = Rect::new(
                     x + padding.left + border.left,
@@ -145,9 +154,10 @@ impl BlockLayout {
                 );
                 let (inline_layout_nodes, inline_result) = LayoutEngine::layout_nodes(
                     dom_tree,
+                    style_tree,
                     &inline_items,
                     LayoutMode::Inline,
-                    &styled_node.style,
+                    style,
                     containing_block,
                     ctx,
                     text_ctx,
@@ -164,7 +174,7 @@ impl BlockLayout {
                 continue;
             }
 
-            let child_margin = PropertyResolver::resolve_margin(&child_style_node.style, container_width);
+            let child_margin = PropertyResolver::resolve_margin(child_style, container_width);
 
             let temp_clearance = if flow.is_first_child {
                 if flow.parent_has_top_fence {
@@ -178,14 +188,14 @@ impl BlockLayout {
 
             let mut child_y_offset = flow.current_y + temp_clearance;
 
-            let clear = child_style_node.style.clear;
+            let clear = child_style.clear;
             let has_clearance = if clear == Clear::None {
                 false
             } else {
                 let absolute_y = y + padding.top + border.top + child_y_offset;
                 let cleared_y = ctx
                     .float_ctx()
-                    .clear_y(clear, child_style_node.style.writing_mode, absolute_y);
+                    .clear_y(clear, child_style.writing_mode, absolute_y);
                 let relative_cleared_y = cleared_y - (y + padding.top + border.top);
                 if relative_cleared_y > child_y_offset {
                     child_y_offset = relative_cleared_y;
@@ -204,24 +214,26 @@ impl BlockLayout {
             child_ctx.set_positioned_containing_block(child_ctx.positioned_containing_block());
             child_ctx.block_cursor.y = child_y_offset;
 
-            if let Some(child_node) = LayoutEngine::layout_node(dom_tree, child_style_node, &mut child_ctx, text_ctx) {
+            if let Some(child_node) =
+                LayoutEngine::layout_node(dom_tree, style_tree, child_style_node_id, &mut child_ctx, text_ctx)
+            {
                 if has_clearance {
                     flow.advance_to(
                         child_y_offset,
                         child_node.dimensions.height,
                         child_node.margin.bottom.to_px(),
-                        child_style_node.style.float != Float::None,
+                        child_style.float != Float::None,
                     );
                 } else {
                     flow.advance(
                         child_node.margin.top.to_px(),
                         child_node.dimensions.height,
                         child_node.margin.bottom.to_px(),
-                        child_style_node.style.float != Float::None,
+                        child_style.float != Float::None,
                     );
                 }
 
-                if child_style_node.style.float != Float::None {
+                if child_style.float != Float::None {
                     ctx.float_ctx().add_float(
                         Rect::new(
                             child_node.dimensions.x,
@@ -229,8 +241,8 @@ impl BlockLayout {
                             child_node.dimensions.width,
                             child_node.dimensions.height,
                         ),
-                        child_style_node.style.writing_mode,
-                        child_style_node.style.float,
+                        child_style.writing_mode,
+                        child_style.float,
                     );
                 }
 
@@ -240,7 +252,7 @@ impl BlockLayout {
             child_idx += 1;
         }
 
-        let has_bottom_fence = PropertyResolver::has_bottom_fence(&styled_node.style, container_width);
+        let has_bottom_fence = PropertyResolver::has_bottom_fence(style, container_width);
 
         let content_height_from_children = if !has_bottom_fence && !children.is_empty() {
             flow.current_y
@@ -248,13 +260,10 @@ impl BlockLayout {
             flow.current_y + flow.previous_margin_bottom
         };
 
-        let calculated_height = PropertyResolver::calculate_height(
-            styled_node,
-            content_height_from_children,
-            ctx.containing_block().height,
-        );
+        let calculated_height =
+            PropertyResolver::calculate_height(style, content_height_from_children, ctx.containing_block().height);
 
-        let final_height = if styled_node.style.height == ComputedSize::Auto {
+        let final_height = if style.height == ComputedSize::Auto {
             content_height_from_children + padding.vertical() + border.vertical()
         } else if child_containing_height > calculated_height {
             child_containing_height + padding.vertical() + border.vertical()
@@ -270,34 +279,28 @@ impl BlockLayout {
             margin.bottom = f64::max(margin.bottom.to_px(), children.last().unwrap().margin.bottom.to_px()).into();
         }
 
-        let colors = LayoutColors::from(styled_node);
+        let colors = LayoutColors::from(style);
 
-        let node = LayoutNode::builder(styled_node.node_id)
+        let node = LayoutNode::builder(*node_id)
             .margin(margin)
             .padding(padding)
             .border(border)
             .colors(colors)
-            .cursor(styled_node.style.cursor)
+            .cursor(style.cursor)
             .children(children)
-            .height_auto(styled_node.style.height == ComputedSize::Auto)
-            .position(styled_node.style.position)
+            .height_auto(style.height == ComputedSize::Auto)
+            .position(style.position)
             .dimensions(Rect::new(x, y, width + padding.horizontal() + border.horizontal(), final_height))
             .build();
 
         Some(node)
     }
 
-    fn is_inline(node: &StyledNode) -> bool {
-        LayoutMode::new(node) == Some(LayoutMode::Inline)
+    fn is_inline(style: &ComputedStyle) -> bool {
+        LayoutMode::new(style) == Some(LayoutMode::Inline)
     }
 
-    fn calculate_width(
-        styled_node: &StyledNode,
-        container_width: f64,
-        padding: &SideOffset,
-        border: &SideOffset,
-    ) -> f64 {
-        let style = &styled_node.style;
+    fn calculate_width(style: &ComputedStyle, container_width: f64, padding: &SideOffset, border: &SideOffset) -> f64 {
         if style.position.is_out_of_flow() {
             let has_left = !style.left.is_auto() && style.left.to_px(container_width) > 0.0;
             let has_right = !style.right.is_auto() && style.right.to_px(container_width) > 0.0;
@@ -308,8 +311,8 @@ impl BlockLayout {
             }
         }
 
-        let specified_width = PropertyResolver::calculate_width(styled_node, container_width);
-        if styled_node.style.width == ComputedSize::Auto {
+        let specified_width = PropertyResolver::calculate_width(style, container_width);
+        if style.width == ComputedSize::Auto {
             (specified_width - padding.horizontal() - border.horizontal()).max(0.0)
         } else {
             specified_width
@@ -317,14 +320,13 @@ impl BlockLayout {
     }
 
     fn calculate_x(
-        styled_node: &StyledNode,
+        style: &ComputedStyle,
         ctx: &LayoutContext,
         margin: &Margin,
         padding: &SideOffset,
         border: &SideOffset,
         content_width: f64,
     ) -> f64 {
-        let style = &styled_node.style;
         let container_width = ctx.containing_block().width;
         let has_left = !style.left.is_auto() && style.left.to_px(container_width) > 0.0;
         let has_right = !style.right.is_auto() && style.right.to_px(container_width) > 0.0;
@@ -334,13 +336,13 @@ impl BlockLayout {
         let right_px = style.right.to_px(container_width);
 
         let total_width = content_width + padding.horizontal() + border.horizontal();
-        let normal_x = if styled_node.style.float == Float::Left {
+        let normal_x = if style.float == Float::Left {
             ctx.containing_block().x + margin_left_px
-        } else if styled_node.style.float == Float::Right {
+        } else if style.float == Float::Right {
             ctx.containing_block().x + container_width - margin_right_px - total_width
-        } else if styled_node.style.margin_left.is_auto() && styled_node.style.margin_right.is_auto() {
+        } else if style.margin_left.is_auto() && style.margin_right.is_auto() {
             ctx.containing_block().x + (container_width - total_width) / 2.0
-        } else if styled_node.style.margin_left.is_auto() {
+        } else if style.margin_left.is_auto() {
             ctx.containing_block().x + container_width - margin_right_px - total_width
         } else {
             ctx.containing_block().x + margin_left_px
@@ -363,8 +365,7 @@ impl BlockLayout {
         normal_x
     }
 
-    fn calculate_y(styled_node: &StyledNode, ctx: &LayoutContext) -> f64 {
-        let style = &styled_node.style;
+    fn calculate_y(style: &ComputedStyle, ctx: &LayoutContext) -> f64 {
         let has_top = !style.top.is_auto() && style.top.to_px(ctx.containing_block().width) > 0.0;
         let has_bottom = !style.bottom.is_auto() && style.bottom.to_px(ctx.containing_block().width) > 0.0;
         let normal_y = ctx.containing_block().y + ctx.block_cursor.y;
@@ -384,8 +385,7 @@ impl BlockLayout {
         normal_y
     }
 
-    fn calculate_height(styled_node: &StyledNode, containing_block_height: f64) -> f64 {
-        let style = &styled_node.style;
+    fn calculate_height(style: &ComputedStyle, containing_block_height: f64) -> f64 {
         let height_is_unconstrained =
             style.height == ComputedSize::Auto || style.height == ComputedSize::Percentage(100.0);
         let has_top = !style.top.is_auto() && style.top.to_px(containing_block_height) > 0.0;
@@ -397,9 +397,9 @@ impl BlockLayout {
 
             (containing_block_height - top_px - bottom_px).max(0.0)
         } else {
-            match styled_node.style.height {
+            match style.height {
                 ComputedSize::Auto => 0.0,
-                _ => PropertyResolver::calculate_height(styled_node, 0.0, containing_block_height).max(0.0),
+                _ => PropertyResolver::calculate_height(style, 0.0, containing_block_height).max(0.0),
             }
         }
     }
@@ -409,7 +409,6 @@ impl BlockLayout {
 mod tests {
     use crate::{ImageContext, position::PositionContext};
     use css_style::{ComputedMargin, ComputedStyle};
-    use html_dom::NodeId;
 
     use super::*;
 
@@ -452,11 +451,6 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
@@ -466,7 +460,7 @@ mod tests {
         let border = SideOffset::zero();
         let content_width = 400.0;
 
-        let x = BlockLayout::calculate_x(&styled_node, &ctx, &margin, &padding, &border, content_width);
+        let x = BlockLayout::calculate_x(&style, &ctx, &margin, &padding, &border, content_width);
 
         assert_eq!(x, 200.0);
     }
@@ -478,11 +472,6 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
@@ -492,7 +481,7 @@ mod tests {
         let border = SideOffset::zero();
         let content_width = 200.0;
 
-        let x = BlockLayout::calculate_x(&styled_node, &ctx, &margin, &padding, &border, content_width);
+        let x = BlockLayout::calculate_x(&style, &ctx, &margin, &padding, &border, content_width);
 
         assert_eq!(x, 0.0);
     }
@@ -504,11 +493,6 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
@@ -518,7 +502,7 @@ mod tests {
         let border = SideOffset::zero();
         let content_width = 200.0;
 
-        let x = BlockLayout::calculate_x(&styled_node, &ctx, &margin, &padding, &border, content_width);
+        let x = BlockLayout::calculate_x(&style, &ctx, &margin, &padding, &border, content_width);
 
         assert_eq!(x, 600.0);
     }
@@ -532,23 +516,12 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
-        let x = BlockLayout::calculate_x(
-            &styled_node,
-            &ctx,
-            &Margin::zero(),
-            &SideOffset::zero(),
-            &SideOffset::zero(),
-            200.0,
-        );
+        let x =
+            BlockLayout::calculate_x(&style, &ctx, &Margin::zero(), &SideOffset::zero(), &SideOffset::zero(), 200.0);
 
         assert_eq!(x, 50.0);
     }
@@ -562,23 +535,12 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
-        let x = BlockLayout::calculate_x(
-            &styled_node,
-            &ctx,
-            &Margin::zero(),
-            &SideOffset::zero(),
-            &SideOffset::zero(),
-            200.0,
-        );
+        let x =
+            BlockLayout::calculate_x(&style, &ctx, &Margin::zero(), &SideOffset::zero(), &SideOffset::zero(), 200.0);
 
         assert_eq!(x, 570.0);
     }
@@ -591,11 +553,6 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
@@ -604,7 +561,7 @@ mod tests {
             left: 40.0.into(),
             ..Margin::zero()
         };
-        let x = BlockLayout::calculate_x(&styled_node, &ctx, &margin, &SideOffset::zero(), &SideOffset::zero(), 200.0);
+        let x = BlockLayout::calculate_x(&style, &ctx, &margin, &SideOffset::zero(), &SideOffset::zero(), 200.0);
 
         assert_eq!(x, 65.0);
     }
@@ -617,11 +574,6 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
@@ -630,7 +582,7 @@ mod tests {
             left: 40.0.into(),
             ..Margin::zero()
         };
-        let x = BlockLayout::calculate_x(&styled_node, &ctx, &margin, &SideOffset::zero(), &SideOffset::zero(), 200.0);
+        let x = BlockLayout::calculate_x(&style, &ctx, &margin, &SideOffset::zero(), &SideOffset::zero(), 200.0);
 
         assert_eq!(x, 10.0);
     }
@@ -643,18 +595,13 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let mut ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
         ctx.block_cursor.y = 120.0;
 
-        let y = BlockLayout::calculate_y(&styled_node, &ctx);
+        let y = BlockLayout::calculate_y(&style, &ctx);
         assert_eq!(y, 20.0);
     }
 
@@ -667,16 +614,11 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
-        let y = BlockLayout::calculate_y(&styled_node, &ctx);
+        let y = BlockLayout::calculate_y(&style, &ctx);
         assert_eq!(y, 32.0);
     }
 
@@ -688,18 +630,13 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let mut ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
         ctx.block_cursor.y = 120.0;
 
-        let y = BlockLayout::calculate_y(&styled_node, &ctx);
+        let y = BlockLayout::calculate_y(&style, &ctx);
         assert_eq!(y, 135.0);
     }
 
@@ -711,18 +648,13 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
         let img_ctx = ImageContext::new();
         let mut position_ctx = PositionContext::new(viewport());
         let mut ctx = LayoutContext::new(viewport(), &img_ctx, &mut position_ctx);
 
         ctx.block_cursor.y = 120.0;
 
-        let y = BlockLayout::calculate_y(&styled_node, &ctx);
+        let y = BlockLayout::calculate_y(&style, &ctx);
         assert_eq!(y, 102.0);
     }
 
@@ -736,12 +668,7 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
-        let height = BlockLayout::calculate_height(&styled_node, 600.0);
+        let height = BlockLayout::calculate_height(&style, 600.0);
         assert_eq!(height, 550.0);
     }
 
@@ -755,12 +682,7 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
-        let height = BlockLayout::calculate_height(&styled_node, 600.0);
+        let height = BlockLayout::calculate_height(&style, 600.0);
         assert_eq!(height, 550.0);
     }
 
@@ -774,12 +696,7 @@ mod tests {
             ..Default::default()
         };
 
-        let styled_node = StyledNode {
-            style,
-            ..StyledNode::new(NodeId(0))
-        };
-
-        let height = BlockLayout::calculate_height(&styled_node, 600.0);
+        let height = BlockLayout::calculate_height(&style, 600.0);
         assert_eq!(height, 0.0);
     }
 }

--- a/crates/layout/src/mode/inline.rs
+++ b/crates/layout/src/mode/inline.rs
@@ -1,4 +1,4 @@
-use css_style::{ComputedSize, ComputedStyle, StyledNode};
+use css_style::{ComputedSize, ComputedStyle, StyleTree};
 use html_dom::{DocumentRoot, NodeId};
 
 use crate::{
@@ -74,22 +74,24 @@ impl InlineLayout {
     /// returning an error if it encounters a block-level element (which should be handled by the block layout instead).
     /// The resulting flat list of inline items is then canonicalised by collapsing whitespace
     /// according to the CSS `white-space` property of each text run and stripping leading/trailing whitespace from lines.
-    pub fn collect_inline_items_from_nodes<'node>(
+    pub fn collect_inline_items_from_nodes<'dom>(
         containing_rect: Rect,
-        dom_tree: &DocumentRoot,
-        parent_style: &'node ComputedStyle,
-        nodes: &'node [&StyledNode],
+        dom_tree: &'dom DocumentRoot,
+        style_tree: &'dom StyleTree,
+        parent_style: &'dom ComputedStyle,
+        nodes: &'dom [NodeId],
         image_ctx: &ImageContext,
-    ) -> Vec<InlineItem<'node>> {
+    ) -> Vec<InlineItem<'dom>> {
         let mut raw_items = Vec::with_capacity(nodes.len() * 2);
 
         for node in nodes {
-            if collect(containing_rect, dom_tree, parent_style, node, &mut raw_items, image_ctx).is_err() {
+            if collect(containing_rect, dom_tree, style_tree, parent_style, node, &mut raw_items, image_ctx).is_err() {
                 break;
             }
         }
 
         canonicalize_whitespace(&mut raw_items);
+
         raw_items
     }
 
@@ -100,6 +102,7 @@ impl InlineLayout {
     /// finally returning the positioned `LayoutNode`s and total height of the laid-out lines.
     pub fn layout(
         dom_tree: &DocumentRoot,
+        style_tree: &StyleTree,
         items: &[InlineItem],
         ctx: &mut LayoutContext,
         text_ctx: &mut TextContext,
@@ -125,12 +128,12 @@ impl InlineLayout {
                     layout_text(&mut inline_layout_ctx, ctx.float_ctx(), text_ctx, &mut line, text);
                 }
                 InlineItem::InlineBoxStart { id, style } => {
-                    line.open_inline_box(&mut inline_layout_ctx.inline_box_stack, text_ctx, *id, style);
+                    line.open_inline_box(&mut inline_layout_ctx.inline_box_stack, text_ctx, **id, style);
                 }
                 InlineItem::InlineBoxEnd { id } => {
-                    line.close_inline_box(&mut inline_layout_ctx.inline_box_stack, *id);
+                    line.close_inline_box(&mut inline_layout_ctx.inline_box_stack, **id);
                 }
-                InlineItem::InlineFlowRoot { node, style } => {
+                InlineItem::InlineFlowRoot { id: node, style } => {
                     let (margin, padding, border) =
                         PropertyResolver::resolve_box_model(style, inline_layout_ctx.available_width);
 
@@ -146,7 +149,9 @@ impl InlineLayout {
                         ctx.position_ctx(),
                     );
 
-                    if let Some(mut layout_node) = LayoutEngine::layout_node(dom_tree, node, &mut block_ctx, text_ctx) {
+                    if let Some(mut layout_node) =
+                        LayoutEngine::layout_node(dom_tree, style_tree, node, &mut block_ctx, text_ctx)
+                    {
                         if style.width == ComputedSize::Auto {
                             layout_node.dimensions.width =
                                 InlineLayout::auto_inline_flow_root_width(&layout_node, padding, border)

--- a/crates/layout/src/mode/inline/collection.rs
+++ b/crates/layout/src/mode/inline/collection.rs
@@ -1,4 +1,4 @@
-use css_style::{ComputedMaxSize, ComputedSize, ComputedStyle, Display, StyledNode};
+use css_style::{ComputedMaxSize, ComputedSize, ComputedStyle, Display, StyleTree};
 use css_values::display::{InsideDisplay, OutsideDisplay};
 use html_dom::{DocumentRoot, HtmlTag, NodeData, NodeId, Tag};
 
@@ -6,14 +6,14 @@ use crate::{ImageContext, Rect};
 
 #[derive(Debug, Clone)]
 pub struct TextRun<'node> {
-    pub id: NodeId,
+    pub id: &'node NodeId,
     pub content: String,
     pub style: &'node ComputedStyle,
 }
 
 #[derive(Debug, Clone)]
 pub struct ImageItem<'node> {
-    pub id: NodeId,
+    pub id: &'node NodeId,
     pub src: String,
     pub width: f64,
     pub height: f64,
@@ -34,17 +34,17 @@ pub enum InlineItem<'node> {
     /// Contributes left border + left padding to the line and begins tracking
     /// a decoration region.
     InlineBoxStart {
-        id: NodeId,
+        id: &'node NodeId,
         style: &'node ComputedStyle,
     },
 
     /// Marks the closing edge of an inline element.
     /// Contributes right border + right padding and finalises the decoration.
-    InlineBoxEnd { id: NodeId },
+    InlineBoxEnd { id: &'node NodeId },
 
     /// inline-block or inline flow-root
     InlineFlowRoot {
-        node: &'node StyledNode,
+        id: &'node NodeId,
         style: &'node ComputedStyle,
     },
 
@@ -57,30 +57,30 @@ pub enum InlineItem<'node> {
 
 /// Recursively collects inline items from the given styled node and its children,
 /// returning an error if it encounters a block-level element (which should be handled by the block layout instead).
-pub fn collect<'node>(
+pub fn collect<'dom>(
     containing_rect: Rect,
-    dom_tree: &DocumentRoot,
-    style: &'node ComputedStyle,
-    inline_node: &'node StyledNode,
-    items: &mut Vec<InlineItem<'node>>,
+    dom_tree: &'dom DocumentRoot,
+    style_tree: &'dom StyleTree,
+    parent_style: &'dom ComputedStyle,
+    node_id: &'dom NodeId,
+    items: &mut Vec<InlineItem<'dom>>,
     image_ctx: &ImageContext,
 ) -> Result<(), ()> {
-    let Some(node) = dom_tree.get_node(&inline_node.node_id) else {
-        return Ok(());
-    };
+    let node = &dom_tree[node_id];
+    let style = &style_tree[node_id];
 
     match &node.data {
         NodeData::Text(content) => {
             items.push(InlineItem::TextRun(TextRun {
-                id: inline_node.node_id,
+                id: node_id,
                 content: content.clone(),
-                style,
+                style: parent_style,
             }));
         }
         NodeData::Element(element) => match element.tag {
             Tag::Html(HtmlTag::Br) => {
                 items.push(InlineItem::Break {
-                    line_height_px: inline_node.style.line_height,
+                    line_height_px: style.line_height,
                 });
             }
             Tag::Html(HtmlTag::Img) => {
@@ -98,14 +98,14 @@ pub fn collect<'node>(
                 let attr_width = attrs.get("width").and_then(|v| v.parse::<f64>().ok());
                 let attr_height = attrs.get("height").and_then(|v| v.parse::<f64>().ok());
 
-                let css_width = !matches!(inline_node.style.width, ComputedSize::Auto);
-                let css_height = !matches!(inline_node.style.height, ComputedSize::Auto);
+                let css_width = !matches!(style.width, ComputedSize::Auto);
+                let css_height = !matches!(style.height, ComputedSize::Auto);
                 let has_explicit_width = css_width || attr_width.is_some();
                 let has_explicit_height = css_height || attr_height.is_some();
 
                 let (width, height, needs_intrinsic_size) = {
                     let w = if css_width {
-                        match inline_node.style.width {
+                        match parent_style.width {
                             ComputedSize::Px(px) => px,
                             ComputedSize::Percentage(frac) => frac * containing_rect.width,
                             _ => known.map_or(DEFAULT_IMAGE_WIDTH, |m| m.0), // TODO: Handle other types of computed size
@@ -117,7 +117,7 @@ pub fn collect<'node>(
                     };
 
                     let h = if css_height {
-                        match inline_node.style.height {
+                        match parent_style.height {
                             ComputedSize::Px(px) => px,
                             ComputedSize::Percentage(frac) => frac * containing_rect.height,
                             _ => known.map_or(DEFAULT_IMAGE_HEIGHT, |m| m.1), // TODO: Handle other types of computed size
@@ -128,13 +128,13 @@ pub fn collect<'node>(
                         known.map_or(DEFAULT_IMAGE_HEIGHT, |m| m.1)
                     };
 
-                    let max_width = match inline_node.style.max_width {
+                    let max_width = match parent_style.max_width {
                         ComputedMaxSize::Px(px) => px,
                         ComputedMaxSize::Percentage(f) => f * containing_rect.width,
                         _ => f64::INFINITY,
                     };
 
-                    let max_height = match inline_node.style.max_height {
+                    let max_height = match parent_style.max_height {
                         ComputedMaxSize::Px(px) => px,
                         _ => f64::INFINITY,
                     };
@@ -151,25 +151,22 @@ pub fn collect<'node>(
                 };
 
                 items.push(InlineItem::Image(ImageItem {
-                    id: inline_node.node_id,
+                    id: node_id,
                     src,
                     width,
                     height,
                     has_explicit_width,
                     has_explicit_height,
                     needs_intrinsic_size,
-                    style: &inline_node.style,
+                    style,
                 }));
             }
             _ => {
-                let display = inline_node.style.display;
+                let display = style.display;
 
                 if let Display::Normal { outside, inside } = display {
                     if outside == Some(OutsideDisplay::Inline) && inside == Some(InsideDisplay::FlowRoot) {
-                        items.push(InlineItem::InlineFlowRoot {
-                            node: inline_node,
-                            style: &inline_node.style,
-                        });
+                        items.push(InlineItem::InlineFlowRoot { id: node_id, style });
 
                         return Ok(());
                     } else if outside != Some(OutsideDisplay::Inline) {
@@ -177,18 +174,15 @@ pub fn collect<'node>(
                     }
                 }
 
-                items.push(InlineItem::InlineBoxStart {
-                    id: inline_node.node_id,
-                    style: &inline_node.style,
-                });
+                items.push(InlineItem::InlineBoxStart { id: node_id, style });
 
-                for child in &inline_node.children {
-                    collect(containing_rect, dom_tree, &inline_node.style, child, items, image_ctx)?;
+                for child_id in &node.children {
+                    let child_style = &style_tree[child_id];
+
+                    collect(containing_rect, dom_tree, style_tree, child_style, child_id, items, image_ctx)?;
                 }
 
-                items.push(InlineItem::InlineBoxEnd {
-                    id: inline_node.node_id,
-                });
+                items.push(InlineItem::InlineBoxEnd { id: node_id });
             }
         },
     }

--- a/crates/layout/src/mode/inline/collection.rs
+++ b/crates/layout/src/mode/inline/collection.rs
@@ -105,7 +105,7 @@ pub fn collect<'dom>(
 
                 let (width, height, needs_intrinsic_size) = {
                     let w = if css_width {
-                        match parent_style.width {
+                        match style.width {
                             ComputedSize::Px(px) => px,
                             ComputedSize::Percentage(frac) => frac * containing_rect.width,
                             _ => known.map_or(DEFAULT_IMAGE_WIDTH, |m| m.0), // TODO: Handle other types of computed size
@@ -117,7 +117,7 @@ pub fn collect<'dom>(
                     };
 
                     let h = if css_height {
-                        match parent_style.height {
+                        match style.height {
                             ComputedSize::Px(px) => px,
                             ComputedSize::Percentage(frac) => frac * containing_rect.height,
                             _ => known.map_or(DEFAULT_IMAGE_HEIGHT, |m| m.1), // TODO: Handle other types of computed size
@@ -128,13 +128,13 @@ pub fn collect<'dom>(
                         known.map_or(DEFAULT_IMAGE_HEIGHT, |m| m.1)
                     };
 
-                    let max_width = match parent_style.max_width {
+                    let max_width = match style.max_width {
                         ComputedMaxSize::Px(px) => px,
                         ComputedMaxSize::Percentage(f) => f * containing_rect.width,
                         _ => f64::INFINITY,
                     };
 
-                    let max_height = match parent_style.max_height {
+                    let max_height = match style.max_height {
                         ComputedMaxSize::Px(px) => px,
                         _ => f64::INFINITY,
                     };

--- a/crates/layout/src/mode/inline/collection.rs
+++ b/crates/layout/src/mode/inline/collection.rs
@@ -177,9 +177,7 @@ pub fn collect<'dom>(
                 items.push(InlineItem::InlineBoxStart { id: node_id, style });
 
                 for child_id in &node.children {
-                    let child_style = &style_tree[child_id];
-
-                    collect(containing_rect, dom_tree, style_tree, child_style, child_id, items, image_ctx)?;
+                    collect(containing_rect, dom_tree, style_tree, style, child_id, items, image_ctx)?;
                 }
 
                 items.push(InlineItem::InlineBoxEnd { id: node_id });

--- a/crates/layout/src/mode/inline/image.rs
+++ b/crates/layout/src/mode/inline/image.rs
@@ -36,7 +36,7 @@ pub fn layout_image<'node>(
         line.finish_line_with_decorations(ctx, text_ctx, layout_ctx.float_ctx_ref(), None);
     }
 
-    let node = LayoutNode::builder(img.id)
+    let node = LayoutNode::builder(*img.id)
         .dimensions(Rect::new(0.0, 0.0, img_width, img_height))
         .colors(LayoutColors::from(img.style))
         .image_data(ImageData {

--- a/crates/layout/src/mode/inline/text.rs
+++ b/crates/layout/src/mode/inline/text.rs
@@ -57,7 +57,7 @@ pub fn layout_text<'node>(
                     float_ctx,
                     &Text {
                         content: segment,
-                        node_id: text.id,
+                        node_id: *text.id,
                         style: text.style,
                         desc: &text_desc,
                     },
@@ -76,7 +76,7 @@ pub fn layout_text<'node>(
             float_ctx,
             &Text {
                 content: &text.content,
-                node_id: text.id,
+                node_id: *text.id,
                 style: text.style,
                 desc: &text_desc,
             },

--- a/crates/layout/src/mode/inline/whitespace.rs
+++ b/crates/layout/src/mode/inline/whitespace.rs
@@ -149,7 +149,7 @@ mod tests {
     fn collapses_whitespace_across_inline_box_boundaries() {
         let style = ComputedStyle::default();
         let mut items = vec![
-            InlineItem::TextRun(crate::mode::inline::collection::TextRun {
+            InlineItem::TextRun(TextRun {
                 id: &NodeId(1),
                 content: "A ".to_string(),
                 style: &style,
@@ -158,13 +158,13 @@ mod tests {
                 id: &NodeId(2),
                 style: &style,
             },
-            InlineItem::TextRun(crate::mode::inline::collection::TextRun {
+            InlineItem::TextRun(TextRun {
                 id: &NodeId(3),
                 content: " ".to_string(),
                 style: &style,
             }),
             InlineItem::InlineBoxEnd { id: &NodeId(2) },
-            InlineItem::TextRun(crate::mode::inline::collection::TextRun {
+            InlineItem::TextRun(TextRun {
                 id: &NodeId(4),
                 content: "B".to_string(),
                 style: &style,

--- a/crates/layout/src/mode/inline/whitespace.rs
+++ b/crates/layout/src/mode/inline/whitespace.rs
@@ -138,8 +138,10 @@ fn strip_edge_whitespace(items: &mut Vec<InlineItem>) {
 
 #[cfg(test)]
 mod tests {
-    use css_style::{ComputedStyle, StyledNode};
+    use css_style::ComputedStyle;
     use html_dom::NodeId;
+
+    use crate::mode::inline::collection::TextRun;
 
     use super::*;
 
@@ -148,22 +150,22 @@ mod tests {
         let style = ComputedStyle::default();
         let mut items = vec![
             InlineItem::TextRun(crate::mode::inline::collection::TextRun {
-                id: NodeId(1),
+                id: &NodeId(1),
                 content: "A ".to_string(),
                 style: &style,
             }),
             InlineItem::InlineBoxStart {
-                id: NodeId(2),
+                id: &NodeId(2),
                 style: &style,
             },
             InlineItem::TextRun(crate::mode::inline::collection::TextRun {
-                id: NodeId(3),
+                id: &NodeId(3),
                 content: " ".to_string(),
                 style: &style,
             }),
-            InlineItem::InlineBoxEnd { id: NodeId(2) },
+            InlineItem::InlineBoxEnd { id: &NodeId(2) },
             InlineItem::TextRun(crate::mode::inline::collection::TextRun {
-                id: NodeId(4),
+                id: &NodeId(4),
                 content: "B".to_string(),
                 style: &style,
             }),
@@ -187,19 +189,18 @@ mod tests {
     #[test]
     fn atomic_items_still_reset_whitespace_collapse_state() {
         let style = ComputedStyle::default();
-        let flow_root = StyledNode::new(NodeId(9));
         let mut items = vec![
-            InlineItem::TextRun(crate::mode::inline::collection::TextRun {
-                id: NodeId(1),
+            InlineItem::TextRun(TextRun {
+                id: &NodeId(1),
                 content: "A ".to_string(),
                 style: &style,
             }),
             InlineItem::InlineFlowRoot {
-                node: &flow_root,
-                style: &flow_root.style,
+                id: &NodeId(2),
+                style: &style,
             },
-            InlineItem::TextRun(crate::mode::inline::collection::TextRun {
-                id: NodeId(2),
+            InlineItem::TextRun(TextRun {
+                id: &NodeId(3),
                 content: " B".to_string(),
                 style: &style,
             }),

--- a/crates/layout/src/position.rs
+++ b/crates/layout/src/position.rs
@@ -1,10 +1,10 @@
 use crate::{ImageContext, LayoutEngine, LayoutNode, Rect, TextContext, layout::LayoutContext};
-use css_style::StyledNode;
-use html_dom::DocumentRoot;
+use css_style::StyleTree;
+use html_dom::{DocumentRoot, NodeId};
 
 #[derive(Debug, Clone)]
 struct PendingPosition {
-    styled_node: Box<StyledNode>,
+    node_id: NodeId,
     containing_block: Rect,
 }
 
@@ -45,9 +45,9 @@ impl PositionContext {
         }
     }
 
-    pub fn defer(&mut self, styled_node: StyledNode, containing_block: Rect) {
+    pub fn defer(&mut self, node_id: &NodeId, containing_block: Rect) {
         self.pending.push(PendingPosition {
-            styled_node: Box::new(styled_node),
+            node_id: *node_id,
             containing_block,
         });
     }
@@ -55,6 +55,7 @@ impl PositionContext {
     pub fn resolve_all(
         &mut self,
         dom_tree: &DocumentRoot,
+        style_tree: &StyleTree,
         image_ctx: &ImageContext,
         text_ctx: &mut TextContext,
     ) -> Vec<LayoutNode> {
@@ -65,7 +66,7 @@ impl PositionContext {
                 let mut ctx =
                     LayoutContext::deferred(pending.containing_block, self.viewport, image_ctx, &mut new_position_ctx);
 
-                LayoutEngine::layout_node(dom_tree, &pending.styled_node, &mut ctx, text_ctx)
+                LayoutEngine::layout_node(dom_tree, style_tree, &pending.node_id, &mut ctx, text_ctx)
             })
             .collect()
     }

--- a/crates/layout/src/resolver.rs
+++ b/crates/layout/src/resolver.rs
@@ -1,4 +1,4 @@
-use css_style::{ComputedMaxSize, ComputedSize, ComputedStyle, StyledNode};
+use css_style::{ComputedMaxSize, ComputedSize, ComputedStyle};
 
 use crate::{
     Margin,
@@ -71,8 +71,8 @@ impl PropertyResolver {
     }
 
     /// Calculate content width (top-down from containing block)
-    pub(crate) fn calculate_width(styled_node: &StyledNode, containing_width: f64) -> f64 {
-        let max_width = match &styled_node.style.max_width {
+    pub(crate) fn calculate_width(style: &ComputedStyle, containing_width: f64) -> f64 {
+        let max_width = match &style.max_width {
             ComputedMaxSize::None => f64::INFINITY,
             ComputedMaxSize::Px(px) => *px,
             ComputedMaxSize::Percentage(f) => (containing_width * f).max(0.0),
@@ -82,8 +82,8 @@ impl PropertyResolver {
             | ComputedMaxSize::Stretch => containing_width, // TODO: Fix
         };
 
-        let left = MarginValue::resolve(styled_node.style.margin_left, containing_width);
-        let right = MarginValue::resolve(styled_node.style.margin_right, containing_width);
+        let left = MarginValue::resolve(style.margin_left, containing_width);
+        let right = MarginValue::resolve(style.margin_right, containing_width);
 
         let available_width = f64::min(
             match (left, right) {
@@ -92,14 +92,14 @@ impl PropertyResolver {
                 (MarginValue::Px(px), MarginValue::Auto) => containing_width - px,
                 (MarginValue::Px(left_px), MarginValue::Px(right_px)) => containing_width - left_px - right_px,
             },
-            if max_width == 0.0 && styled_node.style.width == ComputedSize::Auto {
+            if max_width == 0.0 && style.width == ComputedSize::Auto {
                 f64::INFINITY
             } else {
                 max_width
             },
         );
 
-        let width = match &styled_node.style.width {
+        let width = match &style.width {
             ComputedSize::Auto => available_width.max(0.0),
             ComputedSize::Px(px) => *px,
             ComputedSize::Percentage(f) => (containing_width * f).max(0.0),
@@ -111,8 +111,8 @@ impl PropertyResolver {
         width.min(available_width)
     }
 
-    pub(crate) fn calculate_height(styled_node: &StyledNode, children_height: f64, containing_height: f64) -> f64 {
-        let height = match &styled_node.style.height {
+    pub(crate) fn calculate_height(style: &ComputedStyle, children_height: f64, containing_height: f64) -> f64 {
+        let height = match &style.height {
             ComputedSize::Auto => children_height,
             ComputedSize::Px(px) => *px,
             ComputedSize::Percentage(f) => (containing_height * f).max(0.0),
@@ -121,17 +121,17 @@ impl PropertyResolver {
             }
         };
 
-        if styled_node.style.max_height == ComputedMaxSize::None {
+        if style.max_height == ComputedMaxSize::None {
             height
         } else {
-            let max_height = match &styled_node.style.max_height {
+            let max_height = match &style.max_height {
                 ComputedMaxSize::Px(px) => *px,
                 ComputedMaxSize::Percentage(f) => (containing_height * f).max(0.0),
                 _ => f64::INFINITY,
             };
 
-            let top = MarginValue::resolve(styled_node.style.margin_top, containing_height);
-            let bottom = MarginValue::resolve(styled_node.style.margin_bottom, containing_height);
+            let top = MarginValue::resolve(style.margin_top, containing_height);
+            let bottom = MarginValue::resolve(style.margin_bottom, containing_height);
 
             let available_height = f64::min(
                 match (top, bottom) {
@@ -140,7 +140,7 @@ impl PropertyResolver {
                     (MarginValue::Px(px), MarginValue::Auto) => containing_height - px,
                     (MarginValue::Px(top_px), MarginValue::Px(bottom_px)) => containing_height - top_px - bottom_px,
                 },
-                if max_height == 0.0 && styled_node.style.height == ComputedSize::Auto {
+                if max_height == 0.0 && style.height == ComputedSize::Auto {
                     f64::INFINITY
                 } else {
                     max_height

--- a/crates/layout/tests/integration.rs
+++ b/crates/layout/tests/integration.rs
@@ -343,7 +343,9 @@ mod tests {
 
     #[test]
     fn test_child_calc_percentage_resolves_against_parent_size() {
-        let layout = process_html!("calc_percent_child.html.zst", true);
+        let (dom, style_tree, mut text_ctx) = process_html_raw!("calc_percent_child.html.zst", true);
+
+        let layout = layout_from!(dom, style_tree, &mut text_ctx);
 
         let root = &layout.root_nodes[0];
         let body = &root.children[0];


### PR DESCRIPTION
Flattened the `StyleTree` to a simple `Vec` accessed via the `NodeId` struct as the index. In addition introduce easier access patterns for the `DocumentRoot` (DOM) and `StyleTree`, by implementing the `Index` trait and using it thoughtfully, by ensuring that when accessing either via an index, we can assert that the `NodeId` index is valid.

## Memory
Tested on https://tailwindcss.com/

Before: 696 MB
After: 667 MB

A ~4.1% improvement in usage.

## Performance
A 10% improvement for the `StyleTree` and a overall ~5% for the entire flow, on a Wikipedia page.

### Benchmarks
```
layout/parse_html/wikipedia_tropical_storm.html.zst
                        time:   [15.846 ms 15.923 ms 16.005 ms]
                        change: [−1.1934% −0.2431% +0.7058%] (p = 0.63 > 0.05)
                        No change in performance detected.

layout/style_tree_build/wikipedia_tropical_storm.html.zst/bytes/1304061
                        time:   [72.474 ms 72.630 ms 72.786 ms]
                        thrpt:  [17.086 MiB/s 17.123 MiB/s 17.160 MiB/s]
                 change:
                        time:   [−9.8609% −9.6355% −9.4558%] (p = 0.00 < 0.05)
                        thrpt:  [+10.443% +10.663% +10.940%]
                        Performance has improved.

layout/compute_layout/wikipedia_tropical_storm.html.zst/root_nodes/24904
                        time:   [32.016 ms 32.198 ms 32.331 ms]
                        thrpt:  [770.28 Kelem/s 773.47 Kelem/s 777.86 Kelem/s]

layout/full_pipeline/wikipedia_tropical_storm.html.zst
                        time:   [123.51 ms 123.71 ms 123.94 ms]
                        change: [−5.2809% −4.9621% −4.6808%] (p = 0.00 < 0.05)
                        Performance has improved.
```